### PR TITLE
Add sslVerify parameter for HTTP tiles

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -1509,6 +1509,10 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
           Must be superior or equal to <code>statusCodeMin</code> <br>
           <span class="tag">Default:</span> <code>399</code>
         </dd>
+        <dt><code>sslVerify</code> <code class="type">boolean</code></dt>
+        <dd>
+          Check if SSL certificate is valid, overrides core configuration
+        </dd>
       </dl>
 
       <p class="note">
@@ -1577,6 +1581,10 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
           Maximum HTTP status code <br>
           Must be superior or equal to <code>statusCodeMin</code> <br>
           <span class="tag">Default:</span> <code>399</code>
+        </dd>
+        <dt><code>sslVerify</code> <code class="type">boolean</code></dt>
+        <dd>
+          Check if SSL certificate is valid, overrides core configuration
         </dd>
 
         <dt><code>regex</code> <code class="type">string</code></dt>
@@ -1677,6 +1685,10 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
           Maximum HTTP status code <br>
           Must be superior or equal to <code>statusCodeMin</code> <br>
           <span class="tag">Default:</span> <code>399</code>
+        </dd>
+        <dt><code>sslVerify</code> <code class="type">boolean</code></dt>
+        <dd>
+          Check if SSL certificate is valid, overrides core configuration
         </dd>
 
         <dt><code>regex</code> <code class="type">string</code></dt>

--- a/monitorables/http/api/delivery/http/handlers_test.go
+++ b/monitorables/http/api/delivery/http/handlers_test.go
@@ -34,6 +34,7 @@ func initEcho() (ctx echo.Context, res *httptest.ResponseRecorder) {
 func TestQueryParams_HTTPStatusParams(t *testing.T) {
 	ctx, _ := initEcho()
 	ctx.QueryParams().Set("url", "http://monitoror.example.com")
+	ctx.QueryParams().Set("sslVerify", "false")
 	ctx.QueryParams().Set("statusCodeMin", "300")
 	ctx.QueryParams().Set("statusCodeMax", "400")
 
@@ -42,6 +43,7 @@ func TestQueryParams_HTTPStatusParams(t *testing.T) {
 		URL:           "http://monitoror.example.com",
 		StatusCodeMin: pointer.ToInt(300),
 		StatusCodeMax: pointer.ToInt(400),
+		SSLVerify:     pointer.ToBool(false),
 	}).Return(nil, nil)
 	handler := NewHTTPDelivery(mockUsecase)
 	assert.NoError(t, handler.GetHTTPStatus(ctx))
@@ -51,6 +53,7 @@ func TestQueryParams_HTTPRawParams(t *testing.T) {
 	ctx, _ := initEcho()
 	ctx.QueryParams().Set("url", "http://monitoror.example.com")
 	ctx.QueryParams().Set("regex", "test")
+	ctx.QueryParams().Set("sslVerify", "true")
 	ctx.QueryParams().Set("statusCodeMin", "300")
 	ctx.QueryParams().Set("statusCodeMax", "400")
 
@@ -60,6 +63,7 @@ func TestQueryParams_HTTPRawParams(t *testing.T) {
 		Regex:         "test",
 		StatusCodeMin: pointer.ToInt(300),
 		StatusCodeMax: pointer.ToInt(400),
+		SSLVerify:     pointer.ToBool(true),
 	}).Return(nil, nil)
 	handler := NewHTTPDelivery(mockUsecase)
 	assert.NoError(t, handler.GetHTTPRaw(ctx))
@@ -71,6 +75,7 @@ func TestQueryParams_HTTPFormattedParams(t *testing.T) {
 	ctx.QueryParams().Set("key", "key")
 	ctx.QueryParams().Set("format", "JSON")
 	ctx.QueryParams().Set("regex", "test")
+	ctx.QueryParams().Set("sslVerify", "false")
 	ctx.QueryParams().Set("statusCodeMin", "300")
 	ctx.QueryParams().Set("statusCodeMax", "400")
 
@@ -82,6 +87,7 @@ func TestQueryParams_HTTPFormattedParams(t *testing.T) {
 		Format:        models.JSONFormat,
 		StatusCodeMin: pointer.ToInt(300),
 		StatusCodeMax: pointer.ToInt(400),
+		SSLVerify:     pointer.ToBool(false),
 	}).Return(nil, nil)
 	handler := NewHTTPDelivery(mockUsecase)
 	assert.NoError(t, handler.GetHTTPFormatted(ctx))

--- a/monitorables/http/api/mocks/Repository.go
+++ b/monitorables/http/api/mocks/Repository.go
@@ -12,9 +12,9 @@ type Repository struct {
 	mock.Mock
 }
 
-// Get provides a mock function with given fields: url
-func (_m *Repository) Get(url string) (*models.Response, error) {
-	ret := _m.Called(url)
+// Get provides a mock function with given fields: url, sslVerify
+func (_m *Repository) Get(url string, sslVerify *bool) (*models.Response, error) {
+	ret := _m.Called(url, sslVerify)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -22,19 +22,19 @@ func (_m *Repository) Get(url string) (*models.Response, error) {
 
 	var r0 *models.Response
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*models.Response, error)); ok {
-		return rf(url)
+	if rf, ok := ret.Get(0).(func(string, *bool) (*models.Response, error)); ok {
+		return rf(url, sslVerify)
 	}
-	if rf, ok := ret.Get(0).(func(string) *models.Response); ok {
-		r0 = rf(url)
+	if rf, ok := ret.Get(0).(func(string, *bool) *models.Response); ok {
+		r0 = rf(url, sslVerify)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Response)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(url)
+	if rf, ok := ret.Get(1).(func(string, *bool) error); ok {
+		r1 = rf(url, sslVerify)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/monitorables/http/api/models/formattedparams.go
+++ b/monitorables/http/api/models/formattedparams.go
@@ -16,6 +16,7 @@ type (
 		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
 		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
 		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
 	}
 )
 
@@ -30,6 +31,8 @@ func (p *HTTPFormattedParams) GetStatusCodes() (min int, max int) {
 
 func (p *HTTPFormattedParams) GetRegex() string          { return p.Regex }
 func (p *HTTPFormattedParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
+
+func (p *HTTPFormattedParams) GetSSLVerify() *bool { return p.SSLVerify }
 
 func (p *HTTPFormattedParams) GetKey() string    { return p.Key }
 func (p *HTTPFormattedParams) GetFormat() Format { return p.Format }

--- a/monitorables/http/api/models/formattedparams_faker.go
+++ b/monitorables/http/api/models/formattedparams_faker.go
@@ -17,6 +17,7 @@ type (
 		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
 		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
 		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
 
 		Status      coreModels.TileStatus     `json:"status" query:"status"`
 		Message     string                    `json:"message" query:"message"`
@@ -36,6 +37,8 @@ func (p *HTTPFormattedParams) GetStatusCodes() (min int, max int) {
 
 func (p *HTTPFormattedParams) GetRegex() string          { return p.Regex }
 func (p *HTTPFormattedParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
+
+func (p *HTTPFormattedParams) GetSSLVerify() *bool { return p.SSLVerify }
 
 func (p *HTTPFormattedParams) GetKey() string    { return p.Key }
 func (p *HTTPFormattedParams) GetFormat() Format { return p.Format }

--- a/monitorables/http/api/models/params.go
+++ b/monitorables/http/api/models/params.go
@@ -10,6 +10,7 @@ type (
 	GenericParamsProvider interface {
 		GetURL() (url string)
 		GetStatusCodes() (min int, max int)
+		GetSSLVerify() *bool
 	}
 
 	RegexParamsProvider interface {

--- a/monitorables/http/api/models/rawparams.go
+++ b/monitorables/http/api/models/rawparams.go
@@ -14,6 +14,7 @@ type (
 		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
 		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
 		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
 	}
 )
 
@@ -28,3 +29,4 @@ func (p *HTTPRawParams) GetStatusCodes() (min int, max int) {
 
 func (p *HTTPRawParams) GetRegex() string          { return p.Regex }
 func (p *HTTPRawParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
+func (p *HTTPRawParams) GetSSLVerify() *bool       { return p.SSLVerify }

--- a/monitorables/http/api/models/rawparams_faker.go
+++ b/monitorables/http/api/models/rawparams_faker.go
@@ -15,6 +15,7 @@ type (
 		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
 		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
 		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
 
 		Status      coreModels.TileStatus     `json:"status" query:"status"`
 		Message     string                    `json:"message" query:"message"`
@@ -34,6 +35,7 @@ func (p *HTTPRawParams) GetStatusCodes() (min int, max int) {
 
 func (p *HTTPRawParams) GetRegex() string          { return p.Regex }
 func (p *HTTPRawParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
+func (p *HTTPRawParams) GetSSLVerify() *bool       { return p.SSLVerify }
 
 func (p *HTTPRawParams) GetStatus() coreModels.TileStatus        { return p.Status }
 func (p *HTTPRawParams) GetMessage() string                      { return p.Message }

--- a/monitorables/http/api/models/statusparams.go
+++ b/monitorables/http/api/models/statusparams.go
@@ -11,6 +11,7 @@ type (
 		URL           string `json:"url" query:"url" validate:"required,url,http"`
 		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
 		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
 	}
 )
 
@@ -22,3 +23,5 @@ func (p *HTTPStatusParams) GetURL() (url string) { return p.URL }
 func (p *HTTPStatusParams) GetStatusCodes() (min int, max int) {
 	return getStatusCodesWithDefault(p.StatusCodeMin, p.StatusCodeMax)
 }
+
+func (p *HTTPStatusParams) GetSSLVerify() *bool { return p.SSLVerify }

--- a/monitorables/http/api/models/statusparams_faker.go
+++ b/monitorables/http/api/models/statusparams_faker.go
@@ -12,6 +12,7 @@ type (
 		URL           string `json:"url" query:"url" validate:"required,url,http"`
 		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
 		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
 
 		Status  coreModels.TileStatus `json:"status" query:"status"`
 		Message string                `json:"message" query:"message"`
@@ -26,6 +27,8 @@ func (p *HTTPStatusParams) GetURL() (url string) { return p.URL }
 func (p *HTTPStatusParams) GetStatusCodes() (min int, max int) {
 	return getStatusCodesWithDefault(p.StatusCodeMin, p.StatusCodeMax)
 }
+
+func (p *HTTPStatusParams) GetSSLVerify() *bool { return p.SSLVerify }
 
 func (p *HTTPStatusParams) GetStatus() coreModels.TileStatus        { return p.Status }
 func (p *HTTPStatusParams) GetMessage() string                      { return p.Message }

--- a/monitorables/http/api/repository.go
+++ b/monitorables/http/api/repository.go
@@ -8,6 +8,6 @@ import (
 
 type (
 	Repository interface {
-		Get(url string) (*models.Response, error)
+		Get(url string, sslVerify *bool) (*models.Response, error)
 	}
 )

--- a/monitorables/http/api/repository/http.go
+++ b/monitorables/http/api/repository/http.go
@@ -13,7 +13,9 @@ import (
 
 type (
 	httpRepository struct {
-		httpClient *http.Client
+		verifyClient *http.Client
+		skipClient   *http.Client
+		config       *config.HTTP
 	}
 )
 
@@ -28,16 +30,27 @@ func NewHTTPRepository(config *config.HTTP) api.Repository {
 		}
 	}
 
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: !config.SSLVerify, Certificates: certificates},
-	}
-	client := &http.Client{Transport: tr, Timeout: time.Duration(config.Timeout) * time.Millisecond}
+	trVerify := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: false, Certificates: certificates}}
+	trSkip := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true, Certificates: certificates}}
 
-	return &httpRepository{client}
+	verifyClient := &http.Client{Transport: trVerify, Timeout: time.Duration(config.Timeout) * time.Millisecond}
+	skipClient := &http.Client{Transport: trSkip, Timeout: time.Duration(config.Timeout) * time.Millisecond}
+
+	return &httpRepository{verifyClient: verifyClient, skipClient: skipClient, config: config}
 }
 
-func (r *httpRepository) Get(url string) (response *models.Response, err error) {
-	resp, err := r.httpClient.Get(url)
+func (r *httpRepository) Get(url string, sslVerify *bool) (response *models.Response, err error) {
+	useVerify := r.config.SSLVerify
+	if sslVerify != nil {
+		useVerify = *sslVerify
+	}
+
+	client := r.verifyClient
+	if !useVerify {
+		client = r.skipClient
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		return
 	}

--- a/monitorables/http/api/repository/http_integration_test.go
+++ b/monitorables/http/api/repository/http_integration_test.go
@@ -26,7 +26,7 @@ func TestHTTPRepository_Get(t *testing.T) {
 	defer ts.Close()
 
 	repository := NewHTTPRepository(&config.HTTP{SSLVerify: false, Timeout: 2000})
-	response, err := repository.Get(ts.URL)
+	response, err := repository.Get(ts.URL, nil)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, 200, response.StatusCode)
@@ -36,7 +36,7 @@ func TestHTTPRepository_Get(t *testing.T) {
 
 func TestHTTPRepository_Get_Error(t *testing.T) {
 	repository := NewHTTPRepository(&config.HTTP{SSLVerify: false, Timeout: 2000})
-	_, err := repository.Get("http://monitoror.example.com")
+	_, err := repository.Get("http://monitoror.example.com", nil)
 	assert.Error(t, err)
 }
 
@@ -49,8 +49,8 @@ func TestHTTPRepository_Get_ReadAll_Error(t *testing.T) {
 			Header:     make(http.Header),
 		}
 	})
-	repository := httpRepository{httpClient: client}
+	repository := httpRepository{verifyClient: client, skipClient: client, config: &config.HTTP{SSLVerify: true, Timeout: 2000}}
 
-	_, err := repository.Get("http://monitoror.example.com")
+	_, err := repository.Get("http://monitoror.example.com", nil)
 	assert.Error(t, err)
 }

--- a/monitorables/http/api/usecase/http.go
+++ b/monitorables/http/api/usecase/http.go
@@ -59,7 +59,7 @@ func (hu *httpUsecase) httpAll(tileType coreModels.TileType, params models.Gener
 	tile.Status = coreModels.SuccessStatus
 
 	// Download page
-	response, err := hu.get(params.GetURL())
+	response, err := hu.get(params.GetURL(), params.GetSSLVerify())
 	if err != nil {
 		return nil, &coreModels.MonitororError{Err: err, Tile: tile, Message: fmt.Sprintf("unable to get %s", params.GetURL())}
 	}
@@ -141,7 +141,7 @@ func (hu *httpUsecase) httpAll(tileType coreModels.TileType, params models.Gener
 }
 
 // Adding cache to Repository.Get
-func (hu *httpUsecase) get(url string) (*models.Response, error) {
+func (hu *httpUsecase) get(url string, sslVerify *bool) (*models.Response, error) {
 	response := &models.Response{}
 
 	// Lookup in cache
@@ -152,7 +152,7 @@ func (hu *httpUsecase) get(url string) (*models.Response, error) {
 	}
 
 	// Download page
-	response, err := hu.repository.Get(url)
+	response, err := hu.repository.Get(url, sslVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/monitorables/http/api/usecase/http_test.go
+++ b/monitorables/http/api/usecase/http_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestHTTPStatus_WithError(t *testing.T) {
 	mockRepository := new(mocks.Repository)
-	mockRepository.On("Get", AnythingOfType("string")).Return(nil, context.DeadlineExceeded)
+	mockRepository.On("Get", AnythingOfType("string"), Anything).Return(nil, context.DeadlineExceeded)
 	tu := NewHTTPUsecase(mockRepository, cache.NewGoCacheStore(time.Minute*5, time.Second), 2000)
 
 	tile, err := tu.HTTPStatus(&models.HTTPStatusParams{URL: "toto"})
@@ -145,7 +145,7 @@ func TestHtmlAll_WithoutErrors(t *testing.T) {
 		},
 	} {
 		mockRepository := new(mocks.Repository)
-		mockRepository.On("Get", AnythingOfType("string")).
+		mockRepository.On("Get", AnythingOfType("string"), Anything).
 			Return(&models.Response{StatusCode: 200, Body: []byte(testcase.body)}, nil)
 		tu := NewHTTPUsecase(mockRepository, cache.NewGoCacheStore(time.Minute*5, time.Second), 2000)
 
@@ -166,7 +166,7 @@ func TestHtmlAll_WithoutErrors(t *testing.T) {
 
 func TestHTTPStatus_WithCache(t *testing.T) {
 	mockRepository := new(mocks.Repository)
-	mockRepository.On("Get", AnythingOfType("string")).
+	mockRepository.On("Get", AnythingOfType("string"), Anything).
 		Return(&models.Response{StatusCode: 200, Body: []byte("test with cache")}, nil)
 
 	tu := NewHTTPUsecase(mockRepository, cache.NewGoCacheStore(time.Minute*5, time.Second), 2000)


### PR DESCRIPTION
## Summary
- add `sslVerify` option to HTTP-STATUS, HTTP-RAW and HTTP-FORMATTED checks
- support overriding global HTTP setting via repository
- update handlers and mocks
- document `sslVerify` in docs

## Testing
- `make test-unit` *(fails: gotestsum not found and modules blocked)*
