### PR TITLE
Add UDP support for PORT tile

### DIFF
--- a/docs/assets/demo.monitoror.com-config.json
+++ b/docs/assets/demo.monitoror.com-config.json
@@ -4,7 +4,7 @@
   "tiles": [
     { "type": "HTTP-STATUS", "label": "Monitoror.com", "params": { "url": "https://monitoror.com", "status": "SUCCESS" } },
     { "type": "PING", "label": "Ping GitHub.com", "params": { "hostname": "github.com", "status": "SUCCESS" } },
-    { "type": "PORT", "label": "bastion:22", "params": { "hostname": "bastion", "port": 22, "status": "SUCCESS" } },
+    { "type": "PORT", "label": "bastion:22", "params": { "hostname": "bastion", "port": 22, "type": "tcp", "status": "SUCCESS" } },
     { "type": "GROUP", "label": "Production nodes", "tiles": [
       { "type": "PING", "params": { "hostname": "prod1.monitoror.com", "status": "SUCCESS" } },
       { "type": "PING", "params": { "hostname": "prod2.monitoror.com", "status": "SUCCESS" } },
@@ -18,9 +18,9 @@
     { "type": "HTTP-FORMATTED", "label": "Active users", "params": { "format": "JSON", "url": "https://analytics.example.com/active-users", "key": ".count", "status": "SUCCESS", "valueValues": ["0.1337"], "valueUnit": "RATIO" } },
     { "type": "GROUP", "rowSpan": 2, "label": "QA nodes & deploy", "tiles": [
       { "type": "PING", "params": { "hostname": "qa1.monitoror.com", "status": "SUCCESS" } },
-      { "type": "PORT", "params": { "hostname": "qa1.monitoror.com", "port": 443, "status": "FAILURE" } },
+      { "type": "PORT", "params": { "hostname": "qa1.monitoror.com", "port": 443, "type": "tcp", "status": "FAILURE" } },
       { "type": "PING", "params": { "hostname": "qa1.monitoror.com", "status": "FAILURE" } },
-      { "type": "PORT", "params": { "hostname": "qa2.monitoror.com", "port": 443, "status": "FAILURE" } },
+      { "type": "PORT", "params": { "hostname": "qa2.monitoror.com", "port": 443, "type": "tcp", "status": "FAILURE" } },
       { "type": "GITHUB-CHECKS", "params": { "owner": "monitoror", "repository": "monitoror", "ref": "v5.0.4-qa.2", "status": "FAILURE" } }
     ]},
     { "type": "GROUP", "label": "CI builds in progress", "tiles": [

--- a/docs/documentation/get-started/index.html
+++ b/docs/documentation/get-started/index.html
@@ -212,7 +212,8 @@ chmod +x monitoror
       "label": "Welcome config example",
       "params": {
         "hostname": "127.0.0.1",
-        "port": 8080
+        "port": 8080,
+        "type": "tcp"
       }
     },
     {

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -524,7 +524,7 @@ MO_CONFIG_PRODUCTION="/etc/monitoror/production.json"
     {
       "type": "PORT",
       "label": "Dev server",
-      "params": { "hostname": "127.0.0.1", "port": 8080 }
+      "params": { "hostname": "127.0.0.1", "port": 8080, "type": "tcp" }
     }
   ]
 }
@@ -2318,6 +2318,11 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
         <dd>
           Port to scan
         </dd>
+
+        <dt><code>type</code> <code class="type">string</code></dt>
+        <dd>
+          Protocol to use (<code>tcp</code> or <code>udp</code>). Default is <code>tcp</code>.
+        </dd>
       </dl>
 
       <div class="m-documentation--example-and-demo">
@@ -2326,7 +2331,8 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
   "type": "PORT",
   "params": {
     "hostname": "localhost",
-    "port": 443
+    "port": 443,
+    "type": "tcp"
   }
 }
         </code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -276,7 +276,8 @@
       "label": "Am I on fire?",
       "params": {
         "hostname": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "type": "tcp"
       }
     },
     {

--- a/monitorables/port/api/mocks/Repository.go
+++ b/monitorables/port/api/mocks/Repository.go
@@ -9,17 +9,17 @@ type Repository struct {
 	mock.Mock
 }
 
-// OpenSocket provides a mock function with given fields: hostname, port
-func (_m *Repository) OpenSocket(hostname string, port int) error {
-	ret := _m.Called(hostname, port)
+// OpenSocket provides a mock function with given fields: hostname, port, network
+func (_m *Repository) OpenSocket(hostname string, port int, network string) error {
+	ret := _m.Called(hostname, port, network)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OpenSocket")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, int) error); ok {
-		r0 = rf(hostname, port)
+	if rf, ok := ret.Get(0).(func(string, int, string) error); ok {
+		r0 = rf(hostname, port, network)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/monitorables/port/api/models/params.go
+++ b/monitorables/port/api/models/params.go
@@ -7,10 +7,25 @@ import (
 )
 
 type (
+	PortType string
+
 	PortParams struct {
 		params.Default
 
-		Hostname string `json:"hostname" query:"hostname" validate:"required"`
-		Port     int    `json:"port" query:"port" validate:"required,gt=0"`
+		Hostname string   `json:"hostname" query:"hostname" validate:"required"`
+		Port     int      `json:"port" query:"port" validate:"required,gt=0"`
+		Type     PortType `json:"type,omitempty" query:"type" validate:"omitempty,oneof=tcp udp"`
 	}
 )
+
+const (
+	TCPPortType PortType = "tcp"
+	UDPPortType PortType = "udp"
+)
+
+func (p *PortParams) GetType() PortType {
+	if p.Type == "" {
+		return TCPPortType
+	}
+	return p.Type
+}

--- a/monitorables/port/api/models/params_faker.go
+++ b/monitorables/port/api/models/params_faker.go
@@ -8,12 +8,27 @@ import (
 )
 
 type (
+	PortType string
+
 	PortParams struct {
 		params.Default
 
-		Hostname string `json:"hostname" query:"hostname"`
-		Port     int    `json:"port" query:"port"`
+		Hostname string   `json:"hostname" query:"hostname"`
+		Port     int      `json:"port" query:"port"`
+		Type     PortType `json:"type,omitempty" query:"type"`
 
 		Status coreModels.TileStatus `json:"status" query:"status"`
 	}
 )
+
+const (
+	TCPPortType PortType = "tcp"
+	UDPPortType PortType = "udp"
+)
+
+func (p *PortParams) GetType() PortType {
+	if p.Type == "" {
+		return TCPPortType
+	}
+	return p.Type
+}

--- a/monitorables/port/api/models/params_test.go
+++ b/monitorables/port/api/models/params_test.go
@@ -15,4 +15,7 @@ func TestPortParams_Validate(t *testing.T) {
 
 	param = &PortParams{Hostname: "test", Port: 22}
 	test.AssertParams(t, param, 0)
+
+	param = &PortParams{Hostname: "test", Port: 22, Type: "invalid"}
+	test.AssertParams(t, param, 1)
 }

--- a/monitorables/port/api/repository.go
+++ b/monitorables/port/api/repository.go
@@ -4,6 +4,6 @@ package api
 
 type (
 	Repository interface {
-		OpenSocket(hostname string, port int) error
+		OpenSocket(hostname string, port int, network string) error
 	}
 )

--- a/monitorables/port/api/repository/network.go
+++ b/monitorables/port/api/repository/network.go
@@ -22,14 +22,22 @@ func NewPortRepository(conf *config.Port) api.Repository {
 	return &portRepository{conf, &net.Dialer{Timeout: timeout}}
 }
 
-func (r *portRepository) OpenSocket(hostname string, port int) (err error) {
+func (r *portRepository) OpenSocket(hostname string, port int, network string) (err error) {
 	target := fmt.Sprintf("%s:%d", hostname, port)
 
-	conn, err := r.dialer.Dial("tcp", target)
+	conn, err := r.dialer.Dial(network, target)
 	if err != nil {
 		return
 	}
 	if conn != nil {
+		if network == "udp" {
+			// try to write an empty datagram to validate connection
+			_, err = conn.Write([]byte{})
+			if err != nil {
+				_ = conn.Close()
+				return
+			}
+		}
 		_ = conn.Close()
 	}
 

--- a/monitorables/port/api/repository/network_test.go
+++ b/monitorables/port/api/repository/network_test.go
@@ -34,7 +34,7 @@ func TestRepository_OpenSocket_Success(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		assert.NoError(t, repository.OpenSocket("test", 1234))
+		assert.NoError(t, repository.OpenSocket("test", 1234, "tcp"))
 		mockConn.AssertNumberOfCalls(t, "Close", 1)
 		mockConn.AssertExpectations(t)
 		mockDialer.AssertNumberOfCalls(t, "Dial", 1)
@@ -48,7 +48,7 @@ func TestRepository_OpenSocket_Failed(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		assert.Error(t, repository.OpenSocket("test", 1234))
+		assert.Error(t, repository.OpenSocket("test", 1234, "tcp"))
 		mockDialer.AssertNumberOfCalls(t, "Dial", 1)
 		mockDialer.AssertExpectations(t)
 	}

--- a/monitorables/port/api/usecase/port.go
+++ b/monitorables/port/api/usecase/port.go
@@ -24,7 +24,7 @@ func (pu *portUsecase) Port(params *models.PortParams) (tile *coreModels.Tile, e
 	tile = coreModels.NewTile(api.PortTileType)
 	tile.Label = fmt.Sprintf("%s:%d", params.Hostname, params.Port)
 
-	err = pu.repository.OpenSocket(params.Hostname, params.Port)
+	err = pu.repository.OpenSocket(params.Hostname, params.Port, string(params.GetType()))
 	if err == nil {
 		tile.Status = coreModels.SuccessStatus
 	} else {

--- a/monitorables/port/api/usecase/port_test.go
+++ b/monitorables/port/api/usecase/port_test.go
@@ -17,7 +17,7 @@ import (
 func TestUsecase_CheckPort_Success(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)
-	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int")).Return(nil)
+	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string")).Return(nil)
 	usecase := NewPortUsecase(mockRepo)
 
 	// Params
@@ -44,7 +44,7 @@ func TestUsecase_CheckPort_Success(t *testing.T) {
 func TestUsecase_CheckPort_Fail(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)
-	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int")).Return(errors.New("port error"))
+	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string")).Return(errors.New("port error"))
 	usecase := NewPortUsecase(mockRepo)
 
 	// Params


### PR DESCRIPTION
## Summary
- add `type` parameter to Port tile allowing `tcp` (default) or `udp`
- update repository implementation to handle UDP ports
- adjust mocks and unit tests for new parameter
- document the new option and update example configs
