### PR TITLE
Add custom headers support to HTTP tiles

### DIFF
--- a/api/config/usecase/hydrate.go
+++ b/api/config/usecase/hydrate.go
@@ -65,10 +65,14 @@ func (cu *configUsecase) hydrateTile(configBag *models.ConfigBag, tile *models.T
 	// Change Params by a valid URL
 	urlParams := url.Values{}
 	for key, value := range tile.Params {
-		// Array of value
-		if reflect.TypeOf(value).Kind() == reflect.Slice {
+		rv := reflect.ValueOf(value)
+		if rv.Kind() == reflect.Slice {
 			for _, v := range value.([]interface{}) {
 				urlParams.Add(key, humanize.Interface(v))
+			}
+		} else if rv.Kind() == reflect.Map {
+			for _, mapKey := range rv.MapKeys() {
+				urlParams.Add(fmt.Sprintf("%s[%v]", key, mapKey.Interface()), humanize.Interface(rv.MapIndex(mapKey).Interface()))
 			}
 		} else {
 			urlParams.Add(key, humanize.Interface(value))

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -1513,6 +1513,10 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
         <dd>
           Check if SSL certificate is valid, overrides core configuration
         </dd>
+        <dt><code>headers</code> <code class="type">object</code></dt>
+        <dd>
+          Additional HTTP headers sent with the request
+        </dd>
       </dl>
 
       <p class="note">
@@ -1526,7 +1530,8 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
   "type": "HTTP-STATUS",
   "params": {
     "url": "http://localhost/test",
-    "statusCodeMax": 299
+    "statusCodeMax": 299,
+    "headers": {"User-Agent": "Monitoror"}
   }
 }
         </code></pre>
@@ -1586,6 +1591,10 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
         <dd>
           Check if SSL certificate is valid, overrides core configuration
         </dd>
+        <dt><code>headers</code> <code class="type">object</code></dt>
+        <dd>
+          Additional HTTP headers sent with the request
+        </dd>
 
         <dt><code>regex</code> <code class="type">string</code></dt>
         <dd>
@@ -1609,7 +1618,8 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
   "type": "HTTP-RAW",
   "params": {
     "url": "http://localhost/tag",
-    "regex": "version:\\s*([^\\s]*)"
+    "regex": "version:\\s*([^\\s]*)",
+    "headers": {"User-Agent": "Monitoror"}
   }
 }
         </code></pre>
@@ -1690,6 +1700,10 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
         <dd>
           Check if SSL certificate is valid, overrides core configuration
         </dd>
+        <dt><code>headers</code> <code class="type">object</code></dt>
+        <dd>
+          Additional HTTP headers sent with the request
+        </dd>
 
         <dt><code>regex</code> <code class="type">string</code></dt>
         <dd>
@@ -1714,7 +1728,8 @@ MO_MONITORABLE_HTTP_SSLVERIFY=true
   "params": {
     "url": "http://localhost/count",
     "format": "JSON",
-    "key": "sub.\"dotted.key\".[0]"
+    "key": "sub.\"dotted.key\".[0]",
+    "headers": {"User-Agent": "Monitoror"}
   }
 }
         </code></pre>

--- a/monitorables/http/api/delivery/http/handlers_test.go
+++ b/monitorables/http/api/delivery/http/handlers_test.go
@@ -44,6 +44,7 @@ func TestQueryParams_HTTPStatusParams(t *testing.T) {
 		StatusCodeMin: pointer.ToInt(300),
 		StatusCodeMax: pointer.ToInt(400),
 		SSLVerify:     pointer.ToBool(false),
+		Headers:       nil,
 	}).Return(nil, nil)
 	handler := NewHTTPDelivery(mockUsecase)
 	assert.NoError(t, handler.GetHTTPStatus(ctx))
@@ -64,6 +65,7 @@ func TestQueryParams_HTTPRawParams(t *testing.T) {
 		StatusCodeMin: pointer.ToInt(300),
 		StatusCodeMax: pointer.ToInt(400),
 		SSLVerify:     pointer.ToBool(true),
+		Headers:       nil,
 	}).Return(nil, nil)
 	handler := NewHTTPDelivery(mockUsecase)
 	assert.NoError(t, handler.GetHTTPRaw(ctx))
@@ -88,6 +90,7 @@ func TestQueryParams_HTTPFormattedParams(t *testing.T) {
 		StatusCodeMin: pointer.ToInt(300),
 		StatusCodeMax: pointer.ToInt(400),
 		SSLVerify:     pointer.ToBool(false),
+		Headers:       nil,
 	}).Return(nil, nil)
 	handler := NewHTTPDelivery(mockUsecase)
 	assert.NoError(t, handler.GetHTTPFormatted(ctx))

--- a/monitorables/http/api/mocks/Repository.go
+++ b/monitorables/http/api/mocks/Repository.go
@@ -12,9 +12,9 @@ type Repository struct {
 	mock.Mock
 }
 
-// Get provides a mock function with given fields: url, sslVerify
-func (_m *Repository) Get(url string, sslVerify *bool) (*models.Response, error) {
-	ret := _m.Called(url, sslVerify)
+// Get provides a mock function with given fields: url, headers, sslVerify
+func (_m *Repository) Get(url string, headers map[string]string, sslVerify *bool) (*models.Response, error) {
+	ret := _m.Called(url, headers, sslVerify)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -22,19 +22,19 @@ func (_m *Repository) Get(url string, sslVerify *bool) (*models.Response, error)
 
 	var r0 *models.Response
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, *bool) (*models.Response, error)); ok {
-		return rf(url, sslVerify)
+	if rf, ok := ret.Get(0).(func(string, map[string]string, *bool) (*models.Response, error)); ok {
+		return rf(url, headers, sslVerify)
 	}
-	if rf, ok := ret.Get(0).(func(string, *bool) *models.Response); ok {
-		r0 = rf(url, sslVerify)
+	if rf, ok := ret.Get(0).(func(string, map[string]string, *bool) *models.Response); ok {
+		r0 = rf(url, headers, sslVerify)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.Response)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, *bool) error); ok {
-		r1 = rf(url, sslVerify)
+	if rf, ok := ret.Get(1).(func(string, map[string]string, *bool) error); ok {
+		r1 = rf(url, headers, sslVerify)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/monitorables/http/api/models/formattedparams.go
+++ b/monitorables/http/api/models/formattedparams.go
@@ -10,13 +10,14 @@ import (
 
 type (
 	HTTPFormattedParams struct {
-		URL           string `json:"url" query:"url" validate:"required,url,http"`
-		Format        Format `json:"format" query:"format" validate:"required,oneof=JSON YAML XML"`
-		Key           string `json:"key" query:"key" validate:"required,ne=."`
-		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
-		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
-		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
-		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
+		URL           string            `json:"url" query:"url" validate:"required,url,http"`
+		Format        Format            `json:"format" query:"format" validate:"required,oneof=JSON YAML XML"`
+		Key           string            `json:"key" query:"key" validate:"required,ne=."`
+		Regex         string            `json:"regex,omitempty" query:"regex" validate:"regex"`
+		StatusCodeMin *int              `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
+		StatusCodeMax *int              `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool             `json:"sslVerify,omitempty" query:"sslVerify"`
+		Headers       map[string]string `json:"headers,omitempty" query:"headers"`
 	}
 )
 
@@ -32,7 +33,8 @@ func (p *HTTPFormattedParams) GetStatusCodes() (min int, max int) {
 func (p *HTTPFormattedParams) GetRegex() string          { return p.Regex }
 func (p *HTTPFormattedParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
 
-func (p *HTTPFormattedParams) GetSSLVerify() *bool { return p.SSLVerify }
+func (p *HTTPFormattedParams) GetSSLVerify() *bool           { return p.SSLVerify }
+func (p *HTTPFormattedParams) GetHeaders() map[string]string { return p.Headers }
 
 func (p *HTTPFormattedParams) GetKey() string    { return p.Key }
 func (p *HTTPFormattedParams) GetFormat() Format { return p.Format }

--- a/monitorables/http/api/models/formattedparams_faker.go
+++ b/monitorables/http/api/models/formattedparams_faker.go
@@ -11,13 +11,14 @@ import (
 
 type (
 	HTTPFormattedParams struct {
-		URL           string `json:"url" query:"url" validate:"required,url,http"`
-		Format        Format `json:"format" query:"format" validate:"required,oneof=JSON YAML XML"`
-		Key           string `json:"key" query:"key" validate:"required,ne=."`
-		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
-		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
-		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
-		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
+		URL           string            `json:"url" query:"url" validate:"required,url,http"`
+		Format        Format            `json:"format" query:"format" validate:"required,oneof=JSON YAML XML"`
+		Key           string            `json:"key" query:"key" validate:"required,ne=."`
+		Regex         string            `json:"regex,omitempty" query:"regex" validate:"regex"`
+		StatusCodeMin *int              `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
+		StatusCodeMax *int              `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool             `json:"sslVerify,omitempty" query:"sslVerify"`
+		Headers       map[string]string `json:"headers,omitempty" query:"headers"`
 
 		Status      coreModels.TileStatus     `json:"status" query:"status"`
 		Message     string                    `json:"message" query:"message"`
@@ -38,7 +39,8 @@ func (p *HTTPFormattedParams) GetStatusCodes() (min int, max int) {
 func (p *HTTPFormattedParams) GetRegex() string          { return p.Regex }
 func (p *HTTPFormattedParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
 
-func (p *HTTPFormattedParams) GetSSLVerify() *bool { return p.SSLVerify }
+func (p *HTTPFormattedParams) GetSSLVerify() *bool           { return p.SSLVerify }
+func (p *HTTPFormattedParams) GetHeaders() map[string]string { return p.Headers }
 
 func (p *HTTPFormattedParams) GetKey() string    { return p.Key }
 func (p *HTTPFormattedParams) GetFormat() Format { return p.Format }

--- a/monitorables/http/api/models/params.go
+++ b/monitorables/http/api/models/params.go
@@ -11,6 +11,7 @@ type (
 		GetURL() (url string)
 		GetStatusCodes() (min int, max int)
 		GetSSLVerify() *bool
+		GetHeaders() map[string]string
 	}
 
 	RegexParamsProvider interface {

--- a/monitorables/http/api/models/rawparams.go
+++ b/monitorables/http/api/models/rawparams.go
@@ -10,11 +10,12 @@ import (
 
 type (
 	HTTPRawParams struct {
-		URL           string `json:"url" query:"url" validate:"required,url,http"`
-		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
-		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
-		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
-		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
+		URL           string            `json:"url" query:"url" validate:"required,url,http"`
+		Regex         string            `json:"regex,omitempty" query:"regex" validate:"regex"`
+		StatusCodeMin *int              `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
+		StatusCodeMax *int              `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool             `json:"sslVerify,omitempty" query:"sslVerify"`
+		Headers       map[string]string `json:"headers,omitempty" query:"headers"`
 	}
 )
 
@@ -27,6 +28,7 @@ func (p *HTTPRawParams) GetStatusCodes() (min int, max int) {
 	return getStatusCodesWithDefault(p.StatusCodeMin, p.StatusCodeMax)
 }
 
-func (p *HTTPRawParams) GetRegex() string          { return p.Regex }
-func (p *HTTPRawParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
-func (p *HTTPRawParams) GetSSLVerify() *bool       { return p.SSLVerify }
+func (p *HTTPRawParams) GetRegex() string              { return p.Regex }
+func (p *HTTPRawParams) GetRegexp() *regexp.Regexp     { return getRegexp(p.GetRegex()) }
+func (p *HTTPRawParams) GetSSLVerify() *bool           { return p.SSLVerify }
+func (p *HTTPRawParams) GetHeaders() map[string]string { return p.Headers }

--- a/monitorables/http/api/models/rawparams_faker.go
+++ b/monitorables/http/api/models/rawparams_faker.go
@@ -11,11 +11,12 @@ import (
 
 type (
 	HTTPRawParams struct {
-		URL           string `json:"url" query:"url" validate:"required,url,http"`
-		Regex         string `json:"regex,omitempty" query:"regex" validate:"regex"`
-		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
-		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
-		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
+		URL           string            `json:"url" query:"url" validate:"required,url,http"`
+		Regex         string            `json:"regex,omitempty" query:"regex" validate:"regex"`
+		StatusCodeMin *int              `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
+		StatusCodeMax *int              `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool             `json:"sslVerify,omitempty" query:"sslVerify"`
+		Headers       map[string]string `json:"headers,omitempty" query:"headers"`
 
 		Status      coreModels.TileStatus     `json:"status" query:"status"`
 		Message     string                    `json:"message" query:"message"`
@@ -33,9 +34,10 @@ func (p *HTTPRawParams) GetStatusCodes() (min int, max int) {
 	return getStatusCodesWithDefault(p.StatusCodeMin, p.StatusCodeMax)
 }
 
-func (p *HTTPRawParams) GetRegex() string          { return p.Regex }
-func (p *HTTPRawParams) GetRegexp() *regexp.Regexp { return getRegexp(p.GetRegex()) }
-func (p *HTTPRawParams) GetSSLVerify() *bool       { return p.SSLVerify }
+func (p *HTTPRawParams) GetRegex() string              { return p.Regex }
+func (p *HTTPRawParams) GetRegexp() *regexp.Regexp     { return getRegexp(p.GetRegex()) }
+func (p *HTTPRawParams) GetSSLVerify() *bool           { return p.SSLVerify }
+func (p *HTTPRawParams) GetHeaders() map[string]string { return p.Headers }
 
 func (p *HTTPRawParams) GetStatus() coreModels.TileStatus        { return p.Status }
 func (p *HTTPRawParams) GetMessage() string                      { return p.Message }

--- a/monitorables/http/api/models/statusparams.go
+++ b/monitorables/http/api/models/statusparams.go
@@ -8,10 +8,11 @@ import (
 
 type (
 	HTTPStatusParams struct {
-		URL           string `json:"url" query:"url" validate:"required,url,http"`
-		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
-		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
-		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
+		URL           string            `json:"url" query:"url" validate:"required,url,http"`
+		StatusCodeMin *int              `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
+		StatusCodeMax *int              `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool             `json:"sslVerify,omitempty" query:"sslVerify"`
+		Headers       map[string]string `json:"headers,omitempty" query:"headers"`
 	}
 )
 
@@ -24,4 +25,5 @@ func (p *HTTPStatusParams) GetStatusCodes() (min int, max int) {
 	return getStatusCodesWithDefault(p.StatusCodeMin, p.StatusCodeMax)
 }
 
-func (p *HTTPStatusParams) GetSSLVerify() *bool { return p.SSLVerify }
+func (p *HTTPStatusParams) GetSSLVerify() *bool           { return p.SSLVerify }
+func (p *HTTPStatusParams) GetHeaders() map[string]string { return p.Headers }

--- a/monitorables/http/api/models/statusparams_faker.go
+++ b/monitorables/http/api/models/statusparams_faker.go
@@ -9,10 +9,11 @@ import (
 
 type (
 	HTTPStatusParams struct {
-		URL           string `json:"url" query:"url" validate:"required,url,http"`
-		StatusCodeMin *int   `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
-		StatusCodeMax *int   `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
-		SSLVerify     *bool  `json:"sslVerify,omitempty" query:"sslVerify"`
+		URL           string            `json:"url" query:"url" validate:"required,url,http"`
+		StatusCodeMin *int              `json:"statusCodeMin,omitempty" query:"statusCodeMin"`
+		StatusCodeMax *int              `json:"statusCodeMax,omitempty" query:"statusCodeMax"`
+		SSLVerify     *bool             `json:"sslVerify,omitempty" query:"sslVerify"`
+		Headers       map[string]string `json:"headers,omitempty" query:"headers"`
 
 		Status  coreModels.TileStatus `json:"status" query:"status"`
 		Message string                `json:"message" query:"message"`
@@ -28,7 +29,8 @@ func (p *HTTPStatusParams) GetStatusCodes() (min int, max int) {
 	return getStatusCodesWithDefault(p.StatusCodeMin, p.StatusCodeMax)
 }
 
-func (p *HTTPStatusParams) GetSSLVerify() *bool { return p.SSLVerify }
+func (p *HTTPStatusParams) GetSSLVerify() *bool           { return p.SSLVerify }
+func (p *HTTPStatusParams) GetHeaders() map[string]string { return p.Headers }
 
 func (p *HTTPStatusParams) GetStatus() coreModels.TileStatus        { return p.Status }
 func (p *HTTPStatusParams) GetMessage() string                      { return p.Message }

--- a/monitorables/http/api/repository.go
+++ b/monitorables/http/api/repository.go
@@ -8,6 +8,6 @@ import (
 
 type (
 	Repository interface {
-		Get(url string, sslVerify *bool) (*models.Response, error)
+		Get(url string, headers map[string]string, sslVerify *bool) (*models.Response, error)
 	}
 )

--- a/monitorables/http/api/repository/http.go
+++ b/monitorables/http/api/repository/http.go
@@ -39,7 +39,7 @@ func NewHTTPRepository(config *config.HTTP) api.Repository {
 	return &httpRepository{verifyClient: verifyClient, skipClient: skipClient, config: config}
 }
 
-func (r *httpRepository) Get(url string, sslVerify *bool) (response *models.Response, err error) {
+func (r *httpRepository) Get(url string, headers map[string]string, sslVerify *bool) (response *models.Response, err error) {
 	useVerify := r.config.SSLVerify
 	if sslVerify != nil {
 		useVerify = *sslVerify
@@ -50,7 +50,14 @@ func (r *httpRepository) Get(url string, sslVerify *bool) (response *models.Resp
 		client = r.skipClient
 	}
 
-	resp, err := client.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return
 	}

--- a/monitorables/http/api/repository/http_integration_test.go
+++ b/monitorables/http/api/repository/http_integration_test.go
@@ -26,7 +26,7 @@ func TestHTTPRepository_Get(t *testing.T) {
 	defer ts.Close()
 
 	repository := NewHTTPRepository(&config.HTTP{SSLVerify: false, Timeout: 2000})
-	response, err := repository.Get(ts.URL, nil)
+	response, err := repository.Get(ts.URL, nil, nil)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, 200, response.StatusCode)
@@ -36,7 +36,7 @@ func TestHTTPRepository_Get(t *testing.T) {
 
 func TestHTTPRepository_Get_Error(t *testing.T) {
 	repository := NewHTTPRepository(&config.HTTP{SSLVerify: false, Timeout: 2000})
-	_, err := repository.Get("http://monitoror.example.com", nil)
+	_, err := repository.Get("http://monitoror.example.com", nil, nil)
 	assert.Error(t, err)
 }
 
@@ -51,6 +51,6 @@ func TestHTTPRepository_Get_ReadAll_Error(t *testing.T) {
 	})
 	repository := httpRepository{verifyClient: client, skipClient: client, config: &config.HTTP{SSLVerify: true, Timeout: 2000}}
 
-	_, err := repository.Get("http://monitoror.example.com", nil)
+	_, err := repository.Get("http://monitoror.example.com", nil, nil)
 	assert.Error(t, err)
 }

--- a/monitorables/http/api/usecase/http.go
+++ b/monitorables/http/api/usecase/http.go
@@ -59,7 +59,7 @@ func (hu *httpUsecase) httpAll(tileType coreModels.TileType, params models.Gener
 	tile.Status = coreModels.SuccessStatus
 
 	// Download page
-	response, err := hu.get(params.GetURL(), params.GetSSLVerify())
+	response, err := hu.get(params.GetURL(), params.GetHeaders(), params.GetSSLVerify())
 	if err != nil {
 		return nil, &coreModels.MonitororError{Err: err, Tile: tile, Message: fmt.Sprintf("unable to get %s", params.GetURL())}
 	}
@@ -141,7 +141,7 @@ func (hu *httpUsecase) httpAll(tileType coreModels.TileType, params models.Gener
 }
 
 // Adding cache to Repository.Get
-func (hu *httpUsecase) get(url string, sslVerify *bool) (*models.Response, error) {
+func (hu *httpUsecase) get(url string, headers map[string]string, sslVerify *bool) (*models.Response, error) {
 	response := &models.Response{}
 
 	// Lookup in cache
@@ -152,7 +152,7 @@ func (hu *httpUsecase) get(url string, sslVerify *bool) (*models.Response, error
 	}
 
 	// Download page
-	response, err := hu.repository.Get(url, sslVerify)
+	response, err := hu.repository.Get(url, headers, sslVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/monitorables/http/api/usecase/http_test.go
+++ b/monitorables/http/api/usecase/http_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestHTTPStatus_WithError(t *testing.T) {
 	mockRepository := new(mocks.Repository)
-	mockRepository.On("Get", AnythingOfType("string"), Anything).Return(nil, context.DeadlineExceeded)
+	mockRepository.On("Get", AnythingOfType("string"), Anything, Anything).Return(nil, context.DeadlineExceeded)
 	tu := NewHTTPUsecase(mockRepository, cache.NewGoCacheStore(time.Minute*5, time.Second), 2000)
 
 	tile, err := tu.HTTPStatus(&models.HTTPStatusParams{URL: "toto"})
@@ -145,7 +145,7 @@ func TestHtmlAll_WithoutErrors(t *testing.T) {
 		},
 	} {
 		mockRepository := new(mocks.Repository)
-		mockRepository.On("Get", AnythingOfType("string"), Anything).
+		mockRepository.On("Get", AnythingOfType("string"), Anything, Anything).
 			Return(&models.Response{StatusCode: 200, Body: []byte(testcase.body)}, nil)
 		tu := NewHTTPUsecase(mockRepository, cache.NewGoCacheStore(time.Minute*5, time.Second), 2000)
 
@@ -166,7 +166,7 @@ func TestHtmlAll_WithoutErrors(t *testing.T) {
 
 func TestHTTPStatus_WithCache(t *testing.T) {
 	mockRepository := new(mocks.Repository)
-	mockRepository.On("Get", AnythingOfType("string"), Anything).
+	mockRepository.On("Get", AnythingOfType("string"), Anything, Anything).
 		Return(&models.Response{StatusCode: 200, Body: []byte("test with cache")}, nil)
 
 	tu := NewHTTPUsecase(mockRepository, cache.NewGoCacheStore(time.Minute*5, time.Second), 2000)


### PR DESCRIPTION
## Summary
- allow specifying HTTP headers in tile params
- send headers in HTTP repository requests
- support header params when hydrating config
- document `headers` parameter
