### PR TITLE
Implement customizable SSL tile parameters

### DIFF
--- a/monitorables/ssl/api/delivery/http/handlers_test.go
+++ b/monitorables/ssl/api/delivery/http/handlers_test.go
@@ -24,7 +24,7 @@ func initEcho() (ctx echo.Context, res *httptest.ResponseRecorder) {
 	res = httptest.NewRecorder()
 	ctx = e.NewContext(req, res)
 
-	ctx.QueryParams().Set("hostname", "monitoror.example.com")
+	ctx.QueryParams().Set("domain", "monitoror.example.com")
 	ctx.QueryParams().Set("port", "443")
 	ctx.QueryParams().Set("warnDays", "10")
 
@@ -49,7 +49,7 @@ func TestDelivery_SSLHandler_Success(t *testing.T) {
 	tile.Status = coreModels.SuccessStatus
 
 	mockUsecase := new(mocks.Usecase)
-	mockUsecase.On("SSL", &models.SSLParams{Hostname: "monitoror.example.com", Port: 443, WarnDays: 10}).Return(tile, nil)
+	mockUsecase.On("SSL", &models.SSLParams{Domain: "monitoror.example.com", Port: 443, WarnDays: 10}).Return(tile, nil)
 	handler := NewSSLDelivery(mockUsecase)
 
 	jsonTile, err := json.Marshal(tile)
@@ -63,12 +63,8 @@ func TestDelivery_SSLHandler_Success(t *testing.T) {
 	}
 }
 
-func TestDelivery_SSLHandler_QueryParamsError_MissingHostname(t *testing.T) {
-	missingParam(t, "hostname")
-}
-
-func TestDelivery_SSLHandler_QueryParamsError_MissingPort(t *testing.T) {
-	missingParam(t, "port")
+func TestDelivery_SSLHandler_QueryParamsError_MissingDomain(t *testing.T) {
+	missingParam(t, "domain")
 }
 
 func TestDelivery_SSLHandler_QueryParamsError_MissingWarnDays(t *testing.T) {

--- a/monitorables/ssl/api/models/params.go
+++ b/monitorables/ssl/api/models/params.go
@@ -10,8 +10,16 @@ type (
 	SSLParams struct {
 		params.Default
 
-		Hostname string `json:"hostname" query:"hostname" validate:"required"`
-		Port     int    `json:"port" query:"port" validate:"required,gt=0"`
+		Domain   string `json:"domain" query:"domain" validate:"required"`
+		Port     int    `json:"port,omitempty" query:"port" validate:"omitempty,gt=0"`
 		WarnDays int    `json:"warnDays" query:"warnDays" validate:"required,gte=0"`
+		Display  string `json:"display,omitempty" query:"display"`
 	}
 )
+
+func (p *SSLParams) GetPort() int {
+	if p.Port == 0 {
+		return 443
+	}
+	return p.Port
+}

--- a/monitorables/ssl/api/models/params_test.go
+++ b/monitorables/ssl/api/models/params_test.go
@@ -4,18 +4,24 @@ import (
 	"testing"
 
 	"github.com/monitoror/monitoror/internal/pkg/monitorable/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSSLParams_Validate(t *testing.T) {
 	param := &SSLParams{}
-	test.AssertParams(t, param, 3)
-
-	param = &SSLParams{Hostname: "test"}
 	test.AssertParams(t, param, 2)
 
-	param = &SSLParams{Hostname: "test", Port: 443}
+	param = &SSLParams{Domain: "test"}
 	test.AssertParams(t, param, 1)
 
-	param = &SSLParams{Hostname: "test", Port: 443, WarnDays: 10}
+	param = &SSLParams{Domain: "test", WarnDays: 10}
 	test.AssertParams(t, param, 0)
+}
+
+func TestSSLParams_GetPort(t *testing.T) {
+	p := &SSLParams{Domain: "example.com", WarnDays: 1}
+	assert.Equal(t, 443, p.GetPort())
+
+	p = &SSLParams{Domain: "example.com", Port: 8443, WarnDays: 1}
+	assert.Equal(t, 8443, p.GetPort())
 }

--- a/monitorables/ssl/api/usecase/ssl.go
+++ b/monitorables/ssl/api/usecase/ssl.go
@@ -4,6 +4,7 @@ package usecase
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	coreModels "github.com/monitoror/monitoror/models"
@@ -21,11 +22,12 @@ func NewSSLUsecase(repository api.Repository) api.Usecase {
 
 func (su *sslUsecase) SSL(params *models.SSLParams) (*coreModels.Tile, error) {
 	tile := coreModels.NewTile(api.SSLTileType)
-	tile.Label = fmt.Sprintf("%s:%d", params.Hostname, params.Port)
+	tile.Label = fmt.Sprintf("%s:%d", params.Domain, params.GetPort())
 
-	cert, err := su.repository.FetchCertificate(params.Hostname, params.Port)
+	cert, err := su.repository.FetchCertificate(params.Domain, params.GetPort())
 	if err != nil {
 		tile.Status = coreModels.FailedStatus
+		tile.Message = err.Error()
 		return tile, nil
 	}
 
@@ -36,17 +38,10 @@ func (su *sslUsecase) SSL(params *models.SSLParams) (*coreModels.Tile, error) {
 		tile.Status = coreModels.SuccessStatus
 	}
 
-	// tile.Message = fmt.Sprintf("expires in %d days", remaining)
-	tile.Message = fmt.Sprintf(
-		"Expires in %d days / NotBefore: %s / NotAfter: %s / Issuer: %s",
-		remaining,
-		cert.NotBefore.Format(time.RFC3339),
-		cert.NotAfter.Format(time.RFC3339),
-		cert.Issuer,
-	)
+	tile.Message = buildMessage(params.Display, cert, remaining)
 
 	tile.WithMetrics(coreModels.RawUnit)
-	
+
 	tile.Metrics.Values = []string{
 		cert.NotBefore.Format(time.RFC3339),
 		cert.NotAfter.Format(time.RFC3339),
@@ -55,4 +50,34 @@ func (su *sslUsecase) SSL(params *models.SSLParams) (*coreModels.Tile, error) {
 	}
 
 	return tile, nil
+}
+
+func buildMessage(display string, cert *api.Certificate, remaining int) string {
+	if display == "" || display == "full" {
+		return fmt.Sprintf(
+			"Expires in %d days / NotBefore: %s / NotAfter: %s / Issuer: %s",
+			remaining,
+			cert.NotBefore.Format(time.RFC3339),
+			cert.NotAfter.Format(time.RFC3339),
+			cert.Issuer,
+		)
+	}
+
+	var parts []string
+	for _, field := range strings.Split(display, ",") {
+		switch strings.ToLower(strings.TrimSpace(field)) {
+		case "remaining":
+			parts = append(parts, fmt.Sprintf("%d", remaining))
+		case "notbefore":
+			parts = append(parts, cert.NotBefore.Format(time.RFC3339))
+		case "notafter":
+			parts = append(parts, cert.NotAfter.Format(time.RFC3339))
+		case "issuer":
+			parts = append(parts, cert.Issuer)
+		case "subject":
+			parts = append(parts, cert.Subject)
+		}
+	}
+
+	return strings.Join(parts, " / ")
 }

--- a/monitorables/ssl/api/usecase/ssl_faker.go
+++ b/monitorables/ssl/api/usecase/ssl_faker.go
@@ -4,6 +4,7 @@ package usecase
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/monitoror/monitoror/internal/pkg/monitorable/faker"
@@ -29,20 +30,26 @@ func NewSSLUsecase() api.Usecase {
 
 func (su *sslUsecase) SSL(params *models.SSLParams) (*coreModels.Tile, error) {
 	tile := coreModels.NewTile(api.SSLTileType).WithMetrics(coreModels.RawUnit)
-	tile.Label = fmt.Sprintf("%s:%d", params.Hostname, params.Port)
+	tile.Label = fmt.Sprintf("%s:%d", params.Domain, params.GetPort())
 
 	status := su.computeStatus(params)
 	tile.Status = nonempty.Struct(params.Status, status).(coreModels.TileStatus)
-	remaining := su.computeRemainingDays(params.Hostname)
-	tile.Message = fmt.Sprintf("expires in %d days", remaining)
+	remaining := su.computeRemainingDays(params.Domain)
+	cert := &api.Certificate{
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour * 24 * 90),
+		Issuer:    "issuer",
+		Subject:   "subject",
+	}
+	tile.Message = buildMessage(params.Display, cert, remaining)
 	tile.Metrics.Values = []string{"", "", "issuer", "subject"}
 	return tile, nil
 }
 
 func (su *sslUsecase) computeStatus(params *models.SSLParams) coreModels.TileStatus {
-	value, ok := su.timeRefByHost[params.Hostname]
+	value, ok := su.timeRefByHost[params.Domain]
 	if !ok {
-		su.timeRefByHost[params.Hostname] = faker.GetRefTime()
+		su.timeRefByHost[params.Domain] = faker.GetRefTime()
 	}
 	return faker.ComputeStatus(value, availableStatuses)
 }
@@ -59,4 +66,34 @@ func (su *sslUsecase) computeRemainingDays(hostname string) int {
 		remaining = 90
 	}
 	return remaining
+}
+
+func buildMessage(display string, cert *api.Certificate, remaining int) string {
+	if display == "" || display == "full" {
+		return fmt.Sprintf(
+			"Expires in %d days / NotBefore: %s / NotAfter: %s / Issuer: %s",
+			remaining,
+			cert.NotBefore.Format(time.RFC3339),
+			cert.NotAfter.Format(time.RFC3339),
+			cert.Issuer,
+		)
+	}
+
+	var parts []string
+	for _, field := range strings.Split(display, ",") {
+		switch strings.ToLower(strings.TrimSpace(field)) {
+		case "remaining":
+			parts = append(parts, fmt.Sprintf("%d", remaining))
+		case "notbefore":
+			parts = append(parts, cert.NotBefore.Format(time.RFC3339))
+		case "notafter":
+			parts = append(parts, cert.NotAfter.Format(time.RFC3339))
+		case "issuer":
+			parts = append(parts, cert.Issuer)
+		case "subject":
+			parts = append(parts, cert.Subject)
+		}
+	}
+
+	return strings.Join(parts, " / ")
 }

--- a/monitorables/ssl/api/usecase/ssl_test.go
+++ b/monitorables/ssl/api/usecase/ssl_test.go
@@ -21,13 +21,13 @@ func TestUsecase_SSL_Success(t *testing.T) {
 
 	usecase := NewSSLUsecase(mockRepo)
 
-	param := &models.SSLParams{Hostname: "example.com", Port: 443, WarnDays: 1}
+	param := &models.SSLParams{Domain: "example.com", Port: 443, WarnDays: 1}
 
 	eTile := coreModels.NewTile(api.SSLTileType).WithMetrics(coreModels.RawUnit)
 	eTile.Label = "example.com:443"
 	eTile.Status = coreModels.SuccessStatus
 	remaining := int(cert.NotAfter.Sub(time.Now()).Hours() / 24)
-	eTile.Message = fmt.Sprintf("expires in %d days", remaining)
+	eTile.Message = buildMessage("full", cert, remaining)
 	eTile.Metrics.Values = []string{cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339), "issuer", "subject"}
 
 	rTile, err := usecase.SSL(param)
@@ -46,13 +46,13 @@ func TestUsecase_SSL_Warn(t *testing.T) {
 
 	usecase := NewSSLUsecase(mockRepo)
 
-	param := &models.SSLParams{Hostname: "example.com", Port: 443, WarnDays: 1}
+	param := &models.SSLParams{Domain: "example.com", Port: 443, WarnDays: 1}
 
 	eTile := coreModels.NewTile(api.SSLTileType).WithMetrics(coreModels.RawUnit)
 	eTile.Label = "example.com:443"
 	eTile.Status = coreModels.WarningStatus
 	remaining := int(cert.NotAfter.Sub(time.Now()).Hours() / 24)
-	eTile.Message = fmt.Sprintf("expires in %d days", remaining)
+	eTile.Message = buildMessage("full", cert, remaining)
 	eTile.Metrics.Values = []string{cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339), "issuer", "subject"}
 
 	rTile, err := usecase.SSL(param)
@@ -70,16 +70,35 @@ func TestUsecase_SSL_Fail(t *testing.T) {
 
 	usecase := NewSSLUsecase(mockRepo)
 
-	param := &models.SSLParams{Hostname: "example.com", Port: 443, WarnDays: 1}
+	param := &models.SSLParams{Domain: "example.com", Port: 443, WarnDays: 1}
 
 	eTile := coreModels.NewTile(api.SSLTileType)
 	eTile.Label = "example.com:443"
 	eTile.Status = coreModels.FailedStatus
+	eTile.Message = "fail"
 
 	rTile, err := usecase.SSL(param)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, eTile, rTile)
+		mockRepo.AssertNumberOfCalls(t, "FetchCertificate", 1)
+		mockRepo.AssertExpectations(t)
+	}
+}
+
+func TestUsecase_SSL_CustomDisplay(t *testing.T) {
+	mockRepo := new(mocks.Repository)
+	cert := &api.Certificate{NotBefore: time.Now(), NotAfter: time.Now().Add(48 * time.Hour), Issuer: "issuer", Subject: "subject"}
+	mockRepo.On("FetchCertificate", AnythingOfType("string"), AnythingOfType("int")).Return(cert, nil)
+
+	usecase := NewSSLUsecase(mockRepo)
+
+	param := &models.SSLParams{Domain: "example.com", Port: 443, WarnDays: 1, Display: "issuer"}
+
+	tile, err := usecase.SSL(param)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "issuer", tile.Message)
 		mockRepo.AssertNumberOfCalls(t, "FetchCertificate", 1)
 		mockRepo.AssertExpectations(t)
 	}


### PR DESCRIPTION
## Summary
- update SSL params: rename `hostname` to `domain` and add default port getter
- allow custom message fields with new `display` parameter
- report certificate fetch error in tile
- update faker usecase and tests for new behavior