### PR TITLE
Add payload feature to port monitor

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -2338,6 +2338,10 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
         <dd>
           Protocol to use (<code>tcp</code> or <code>udp</code>). Default is <code>tcp</code>.
         </dd>
+        <dt><code>payload</code> <code class="type">string</code></dt>
+        <dd>
+          Hex payload sent after connection is established
+        </dd>
       </dl>
 
       <div class="m-documentation--example-and-demo">
@@ -2347,7 +2351,8 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
   "params": {
     "hostname": "localhost",
     "port": 443,
-    "type": "tcp"
+    "type": "tcp",
+    "payload": "48656c6c6f"
   }
 }
         </code></pre>

--- a/monitorables/port/api/mocks/Repository.go
+++ b/monitorables/port/api/mocks/Repository.go
@@ -10,16 +10,16 @@ type Repository struct {
 }
 
 // OpenSocket provides a mock function with given fields: hostname, port, network
-func (_m *Repository) OpenSocket(hostname string, port int, network string) error {
-	ret := _m.Called(hostname, port, network)
+func (_m *Repository) OpenSocket(hostname string, port int, network string, payload []byte) error {
+	ret := _m.Called(hostname, port, network, payload)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OpenSocket")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, int, string) error); ok {
-		r0 = rf(hostname, port, network)
+	if rf, ok := ret.Get(0).(func(string, int, string, []byte) error); ok {
+		r0 = rf(hostname, port, network, payload)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/monitorables/port/api/models/params.go
+++ b/monitorables/port/api/models/params.go
@@ -15,6 +15,7 @@ type (
 		Hostname string   `json:"hostname" query:"hostname" validate:"required"`
 		Port     int      `json:"port" query:"port" validate:"required,gt=0"`
 		Type     PortType `json:"type,omitempty" query:"type" validate:"omitempty,oneof=tcp udp"`
+		Payload  string   `json:"payload,omitempty" query:"payload" validate:"omitempty,hexadecimal"`
 	}
 )
 

--- a/monitorables/port/api/models/params_faker.go
+++ b/monitorables/port/api/models/params_faker.go
@@ -16,6 +16,7 @@ type (
 		Hostname string   `json:"hostname" query:"hostname"`
 		Port     int      `json:"port" query:"port"`
 		Type     PortType `json:"type,omitempty" query:"type"`
+		Payload  string   `json:"payload,omitempty" query:"payload"`
 
 		Status coreModels.TileStatus `json:"status" query:"status"`
 	}

--- a/monitorables/port/api/repository.go
+++ b/monitorables/port/api/repository.go
@@ -4,6 +4,6 @@ package api
 
 type (
 	Repository interface {
-		OpenSocket(hostname string, port int, network string) error
+		OpenSocket(hostname string, port int, network string, payload []byte) error
 	}
 )

--- a/monitorables/port/api/repository/network.go
+++ b/monitorables/port/api/repository/network.go
@@ -22,7 +22,7 @@ func NewPortRepository(conf *config.Port) api.Repository {
 	return &portRepository{conf, &net.Dialer{Timeout: timeout}}
 }
 
-func (r *portRepository) OpenSocket(hostname string, port int, network string) (err error) {
+func (r *portRepository) OpenSocket(hostname string, port int, network string, payload []byte) (err error) {
 	target := fmt.Sprintf("%s:%d", hostname, port)
 
 	conn, err := r.dialer.Dial(network, target)
@@ -30,7 +30,13 @@ func (r *portRepository) OpenSocket(hostname string, port int, network string) (
 		return
 	}
 	if conn != nil {
-		if network == "udp" {
+		if len(payload) > 0 {
+			_, err = conn.Write(payload)
+			if err != nil {
+				_ = conn.Close()
+				return
+			}
+		} else if network == "udp" {
 			// try to write an empty datagram to validate connection
 			_, err = conn.Write([]byte{})
 			if err != nil {

--- a/monitorables/port/api/repository/network_test.go
+++ b/monitorables/port/api/repository/network_test.go
@@ -34,11 +34,29 @@ func TestRepository_OpenSocket_Success(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		assert.NoError(t, repository.OpenSocket("test", 1234, "tcp"))
+		assert.NoError(t, repository.OpenSocket("test", 1234, "tcp", nil))
 		mockConn.AssertNumberOfCalls(t, "Close", 1)
 		mockConn.AssertExpectations(t)
 		mockDialer.AssertNumberOfCalls(t, "Dial", 1)
 		mockDialer.AssertExpectations(t)
+	}
+}
+
+func TestRepository_OpenSocket_Success_WithPayload(t *testing.T) {
+	mockConn := new(mocks.Conn)
+	mockConn.On("Close").Return(nil)
+	payload := []byte{0x01, 0x02}
+	mockConn.On("Write", payload).Return(len(payload), nil)
+
+	mockDialer := new(mocks.Dialer)
+	mockDialer.On("Dial", AnythingOfType("string"), AnythingOfType("string")).Return(mockConn, nil)
+
+	repository := initRepository(t, mockDialer)
+	if repository != nil {
+		assert.NoError(t, repository.OpenSocket("test", 1234, "udp", payload))
+		mockConn.AssertCalled(t, "Write", payload)
+		mockConn.AssertNumberOfCalls(t, "Close", 1)
+		mockDialer.AssertNumberOfCalls(t, "Dial", 1)
 	}
 }
 
@@ -48,7 +66,7 @@ func TestRepository_OpenSocket_Failed(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		assert.Error(t, repository.OpenSocket("test", 1234, "tcp"))
+		assert.Error(t, repository.OpenSocket("test", 1234, "tcp", nil))
 		mockDialer.AssertNumberOfCalls(t, "Dial", 1)
 		mockDialer.AssertExpectations(t)
 	}

--- a/monitorables/port/api/usecase/port.go
+++ b/monitorables/port/api/usecase/port.go
@@ -3,6 +3,7 @@
 package usecase
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	coreModels "github.com/monitoror/monitoror/models"
@@ -24,7 +25,17 @@ func (pu *portUsecase) Port(params *models.PortParams) (tile *coreModels.Tile, e
 	tile = coreModels.NewTile(api.PortTileType)
 	tile.Label = fmt.Sprintf("%s:%d", params.Hostname, params.Port)
 
-	err = pu.repository.OpenSocket(params.Hostname, params.Port, string(params.GetType()))
+	var payload []byte
+	if params.Payload != "" {
+		payload, err = hex.DecodeString(params.Payload)
+		if err != nil {
+			tile.Status = coreModels.FailedStatus
+			err = nil
+			return
+		}
+	}
+
+	err = pu.repository.OpenSocket(params.Hostname, params.Port, string(params.GetType()), payload)
 	if err == nil {
 		tile.Status = coreModels.SuccessStatus
 	} else {

--- a/monitorables/port/api/usecase/port_test.go
+++ b/monitorables/port/api/usecase/port_test.go
@@ -17,7 +17,7 @@ import (
 func TestUsecase_CheckPort_Success(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)
-	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string")).Return(nil)
+	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string"), Anything).Return(nil)
 	usecase := NewPortUsecase(mockRepo)
 
 	// Params
@@ -44,7 +44,7 @@ func TestUsecase_CheckPort_Success(t *testing.T) {
 func TestUsecase_CheckPort_Fail(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)
-	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string")).Return(errors.New("port error"))
+	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string"), Anything).Return(errors.New("port error"))
 	usecase := NewPortUsecase(mockRepo)
 
 	// Params
@@ -59,6 +59,32 @@ func TestUsecase_CheckPort_Fail(t *testing.T) {
 	eTile.Status = coreModels.FailedStatus
 
 	// Test
+	rTile, err := usecase.Port(param)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, eTile, rTile)
+		mockRepo.AssertNumberOfCalls(t, "OpenSocket", 1)
+		mockRepo.AssertExpectations(t)
+	}
+}
+
+func TestUsecase_CheckPort_WithPayload(t *testing.T) {
+	mockRepo := new(mocks.Repository)
+	payload := []byte{0xde, 0xad}
+	mockRepo.On("OpenSocket", "monitoror.example.com", 1234, "udp", payload).Return(nil)
+	usecase := NewPortUsecase(mockRepo)
+
+	param := &models.PortParams{
+		Hostname: "monitoror.example.com",
+		Port:     1234,
+		Type:     models.UDPPortType,
+		Payload:  "dead",
+	}
+
+	eTile := coreModels.NewTile(api.PortTileType)
+	eTile.Label = fmt.Sprintf("%s:%d", param.Hostname, param.Port)
+	eTile.Status = coreModels.SuccessStatus
+
 	rTile, err := usecase.Port(param)
 
 	if assert.NoError(t, err) {


### PR DESCRIPTION
## Summary
- allow specifying optional hex payload for the PORT monitor
- send payload after dialing socket
- document `payload` parameter
- update tests and mocks