### PR TITLE
Add regex display and string payload for port monitorable

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -2340,7 +2340,11 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
         </dd>
         <dt><code>payload</code> <code class="type">string</code></dt>
         <dd>
-          Hex payload sent after connection is established
+          Payload sent after connection is established. Use the <code>0x</code> prefix for hexadecimal data or escape sequences like <code>\n</code> and <code>\xFF</code>.
+        </dd>
+        <dt><code>display</code> <code class="type">string</code></dt>
+        <dd>
+          Optional regular expression used to extract information from the service banner.
         </dd>
       </dl>
 
@@ -2352,7 +2356,8 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
     "hostname": "localhost",
     "port": 443,
     "type": "tcp",
-    "payload": "48656c6c6f"
+    "payload": "0x48656c6c6f",
+    "display": "SSH-2.0-(.*)"
   }
 }
         </code></pre>

--- a/monitorables/port/api/mocks/Repository.go
+++ b/monitorables/port/api/mocks/Repository.go
@@ -13,7 +13,7 @@ type Repository struct {
 }
 
 // OpenSocket provides a mock function with given fields: hostname, port, network
-func (_m *Repository) OpenSocket(hostname string, port int, network string, payload []byte) (bool, time.Duration, error) {
+func (_m *Repository) OpenSocket(hostname string, port int, network string, payload []byte) (bool, string, time.Duration, error) {
 	ret := _m.Called(hostname, port, network, payload)
 
 	if len(ret) == 0 {
@@ -21,9 +21,10 @@ func (_m *Repository) OpenSocket(hostname string, port int, network string, payl
 	}
 
 	var r0 bool
-	var r1 time.Duration
-	var r2 error
-	if rf, ok := ret.Get(0).(func(string, int, string, []byte) (bool, time.Duration, error)); ok {
+	var r1 string
+	var r2 time.Duration
+	var r3 error
+	if rf, ok := ret.Get(0).(func(string, int, string, []byte) (bool, string, time.Duration, error)); ok {
 		return rf(hostname, port, network, payload)
 	}
 	if rf, ok := ret.Get(0).(func(string, int, string, []byte) bool); ok {
@@ -31,20 +32,27 @@ func (_m *Repository) OpenSocket(hostname string, port int, network string, payl
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if rf, ok := ret.Get(1).(func(string, int, string, []byte) time.Duration); ok {
+	if rf, ok := ret.Get(1).(func(string, int, string, []byte) string); ok {
 		r1 = rf(hostname, port, network, payload)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(time.Duration)
+			r1 = ret.Get(1).(string)
 		}
 	}
-	if rf, ok := ret.Get(2).(func(string, int, string, []byte) error); ok {
+	if rf, ok := ret.Get(2).(func(string, int, string, []byte) time.Duration); ok {
 		r2 = rf(hostname, port, network, payload)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(time.Duration)
+		}
+	}
+	if rf, ok := ret.Get(3).(func(string, int, string, []byte) error); ok {
+		r3 = rf(hostname, port, network, payload)
+	} else {
+		r3 = ret.Error(3)
 	}
 
-	return r0, r1, r2
+	return r0, r1, r2, r3
 }
 
 // NewRepository creates a new instance of Repository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/monitorables/port/api/models/params.go
+++ b/monitorables/port/api/models/params.go
@@ -15,7 +15,8 @@ type (
 		Hostname string   `json:"hostname" query:"hostname" validate:"required"`
 		Port     int      `json:"port" query:"port" validate:"required,gt=0"`
 		Type     PortType `json:"type,omitempty" query:"type" validate:"omitempty,oneof=tcp udp"`
-		Payload  string   `json:"payload,omitempty" query:"payload" validate:"omitempty,hexadecimal"`
+		Payload  string   `json:"payload,omitempty" query:"payload"`
+		Display  string   `json:"display,omitempty" query:"display" validate:"omitempty,regex"`
 	}
 )
 

--- a/monitorables/port/api/models/params_faker.go
+++ b/monitorables/port/api/models/params_faker.go
@@ -17,6 +17,7 @@ type (
 		Port     int      `json:"port" query:"port"`
 		Type     PortType `json:"type,omitempty" query:"type"`
 		Payload  string   `json:"payload,omitempty" query:"payload"`
+		Display  string   `json:"display,omitempty" query:"display"`
 
 		Status coreModels.TileStatus `json:"status" query:"status"`
 	}

--- a/monitorables/port/api/repository.go
+++ b/monitorables/port/api/repository.go
@@ -7,7 +7,7 @@ import "time"
 type (
 	Repository interface {
 		// OpenSocket tries to connect and optionally send a payload.
-		// It returns if the remote answered at least one byte and the connection time.
-		OpenSocket(hostname string, port int, network string, payload []byte) (bool, time.Duration, error)
+		// It returns if the remote answered at least one byte, the received banner and the connection time.
+		OpenSocket(hostname string, port int, network string, payload []byte) (bool, string, time.Duration, error)
 	}
 )

--- a/monitorables/port/api/repository/network.go
+++ b/monitorables/port/api/repository/network.go
@@ -23,16 +23,16 @@ func NewPortRepository(conf *config.Port) api.Repository {
 	return &portRepository{conf, &net.Dialer{Timeout: timeout}}
 }
 
-func (r *portRepository) OpenSocket(hostname string, port int, network string, payload []byte) (responding bool, duration time.Duration, err error) {
+func (r *portRepository) OpenSocket(hostname string, port int, network string, payload []byte) (responding bool, banner string, duration time.Duration, err error) {
 	start := time.Now()
 	target := fmt.Sprintf("%s:%d", hostname, port)
 
 	conn, err := r.dialer.Dial(network, target)
 	if err != nil {
-		return false, time.Since(start), err
+		return false, "", time.Since(start), err
 	}
 	if conn == nil {
-		return false, time.Since(start), fmt.Errorf("no connection")
+		return false, "", time.Since(start), fmt.Errorf("no connection")
 	}
 	defer conn.Close()
 
@@ -41,18 +41,21 @@ func (r *portRepository) OpenSocket(hostname string, port int, network string, p
 
 	if len(payload) > 0 {
 		if _, err = conn.Write(payload); err != nil {
-			return false, time.Since(start), err
+			return false, "", time.Since(start), err
 		}
 	} else if network == "udp" {
 		// send empty datagram to validate connection
 		if _, err = conn.Write([]byte{}); err != nil {
-			return false, time.Since(start), err
+			return false, "", time.Since(start), err
 		}
 	}
 
-	buf := make([]byte, 1)
-	_, err = conn.Read(buf)
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
 	duration = time.Since(start)
+	if n > 0 {
+		banner = string(buf[:n])
+	}
 	if err == nil || err == io.EOF {
 		responding = true
 		err = nil

--- a/monitorables/port/api/repository/network_test.go
+++ b/monitorables/port/api/repository/network_test.go
@@ -38,7 +38,7 @@ func TestRepository_OpenSocket_Success(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		responding, _, err := repository.OpenSocket("test", 1234, "tcp", nil)
+		responding, _, _, err := repository.OpenSocket("test", 1234, "tcp", nil)
 		assert.NoError(t, err)
 		assert.True(t, responding)
 		mockConn.AssertNumberOfCalls(t, "Close", 1)
@@ -61,7 +61,7 @@ func TestRepository_OpenSocket_Success_WithPayload(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		responding, _, err := repository.OpenSocket("test", 1234, "udp", payload)
+		responding, _, _, err := repository.OpenSocket("test", 1234, "udp", payload)
 		assert.NoError(t, err)
 		assert.True(t, responding)
 		mockConn.AssertCalled(t, "Write", payload)
@@ -76,7 +76,7 @@ func TestRepository_OpenSocket_Failed(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		_, _, err := repository.OpenSocket("test", 1234, "tcp", nil)
+		_, _, _, err := repository.OpenSocket("test", 1234, "tcp", nil)
 		assert.Error(t, err)
 		mockDialer.AssertNumberOfCalls(t, "Dial", 1)
 		mockDialer.AssertExpectations(t)
@@ -94,7 +94,7 @@ func TestRepository_OpenSocket_NoResponse(t *testing.T) {
 
 	repository := initRepository(t, mockDialer)
 	if repository != nil {
-		responding, _, err := repository.OpenSocket("test", 1234, "tcp", nil)
+		responding, _, _, err := repository.OpenSocket("test", 1234, "tcp", nil)
 		assert.NoError(t, err)
 		assert.True(t, responding)
 		mockConn.AssertNumberOfCalls(t, "Close", 1)

--- a/monitorables/port/api/usecase/port.go
+++ b/monitorables/port/api/usecase/port.go
@@ -5,6 +5,8 @@ package usecase
 import (
 	"encoding/hex"
 	"fmt"
+	"regexp"
+	"strconv"
 
 	coreModels "github.com/monitoror/monitoror/models"
 	"github.com/monitoror/monitoror/monitorables/port/api"
@@ -27,7 +29,13 @@ func (pu *portUsecase) Port(params *models.PortParams) (tile *coreModels.Tile, e
 
 	var payload []byte
 	if params.Payload != "" {
-		payload, err = hex.DecodeString(params.Payload)
+		if matched, _ := regexp.MatchString(`^0x[0-9a-fA-F]+$`, params.Payload); matched {
+			payload, err = hex.DecodeString(params.Payload[2:])
+		} else {
+			var s string
+			s, err = strconv.Unquote("\"" + params.Payload + "\"")
+			payload = []byte(s)
+		}
 		if err != nil {
 			tile.Status = coreModels.FailedStatus
 			err = nil
@@ -35,7 +43,7 @@ func (pu *portUsecase) Port(params *models.PortParams) (tile *coreModels.Tile, e
 		}
 	}
 
-	responding, duration, err := pu.repository.OpenSocket(params.Hostname, params.Port, string(params.GetType()), payload)
+	responding, banner, duration, err := pu.repository.OpenSocket(params.Hostname, params.Port, string(params.GetType()), payload)
 	if err != nil {
 		tile.Status = coreModels.FailedStatus
 		err = nil
@@ -46,6 +54,18 @@ func (pu *portUsecase) Port(params *models.PortParams) (tile *coreModels.Tile, e
 	tile.Message = "no response"
 	if responding {
 		tile.Message = "responding"
+	}
+
+	if params.Display != "" && banner != "" {
+		if re, e := regexp.Compile(params.Display); e == nil {
+			if m := re.FindStringSubmatch(banner); m != nil {
+				if len(m) > 1 {
+					tile.Message = m[1]
+				} else {
+					tile.Message = m[0]
+				}
+			}
+		}
 	}
 
 	tile.WithMetrics(coreModels.MillisecondUnit)

--- a/monitorables/port/api/usecase/port_test.go
+++ b/monitorables/port/api/usecase/port_test.go
@@ -18,7 +18,7 @@ import (
 func TestUsecase_CheckPort_Success(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)
-	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string"), Anything).Return(true, time.Millisecond*50, nil)
+	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string"), Anything).Return(true, "SSH-2.0-openSSH", time.Millisecond*50, nil)
 	usecase := NewPortUsecase(mockRepo)
 
 	// Params
@@ -47,7 +47,7 @@ func TestUsecase_CheckPort_Success(t *testing.T) {
 func TestUsecase_CheckPort_Fail(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)
-	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string"), Anything).Return(false, time.Millisecond*0, errors.New("port error"))
+	mockRepo.On("OpenSocket", AnythingOfType("string"), AnythingOfType("int"), AnythingOfType("string"), Anything).Return(false, "", time.Millisecond*0, errors.New("port error"))
 	usecase := NewPortUsecase(mockRepo)
 
 	// Params
@@ -74,7 +74,7 @@ func TestUsecase_CheckPort_Fail(t *testing.T) {
 func TestUsecase_CheckPort_WithPayload(t *testing.T) {
 	mockRepo := new(mocks.Repository)
 	payload := []byte{0xde, 0xad}
-	mockRepo.On("OpenSocket", "monitoror.example.com", 1234, "udp", payload).Return(true, time.Millisecond*10, nil)
+	mockRepo.On("OpenSocket", "monitoror.example.com", 1234, "udp", payload).Return(true, "pong", time.Millisecond*10, nil)
 	usecase := NewPortUsecase(mockRepo)
 
 	param := &models.PortParams{
@@ -89,6 +89,32 @@ func TestUsecase_CheckPort_WithPayload(t *testing.T) {
 	eTile.Status = coreModels.SuccessStatus
 	eTile.Message = "responding"
 	eTile.Metrics.Values = []string{"10"}
+
+	rTile, err := usecase.Port(param)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, eTile, rTile)
+		mockRepo.AssertNumberOfCalls(t, "OpenSocket", 1)
+		mockRepo.AssertExpectations(t)
+	}
+}
+
+func TestUsecase_CheckPort_Display(t *testing.T) {
+	mockRepo := new(mocks.Repository)
+	mockRepo.On("OpenSocket", "monitoror.example.com", 22, "tcp", Anything).Return(true, "SSH-2.0-OpenSSH_7.9", time.Millisecond*5, nil)
+	usecase := NewPortUsecase(mockRepo)
+
+	param := &models.PortParams{
+		Hostname: "monitoror.example.com",
+		Port:     22,
+		Display:  `SSH-2.0-(.*)`,
+	}
+
+	eTile := coreModels.NewTile(api.PortTileType).WithMetrics(coreModels.MillisecondUnit)
+	eTile.Label = "monitoror.example.com:22"
+	eTile.Status = coreModels.SuccessStatus
+	eTile.Message = "OpenSSH_7.9"
+	eTile.Metrics.Values = []string{"5"}
 
 	rTile, err := usecase.Port(param)
 


### PR DESCRIPTION
## Summary
- support capturing banners with a new `display` regex option for the PORT tile
- allow payloads to be sent as strings with escape sequences or as hexadecimal when prefixed with `0x`
- expose service banner from `OpenSocket`
- document new parameters
- update unit tests
