### PR TITLE
Handle sub-ms ping

### DIFF
--- a/monitorables/ping/api/usecase/ping.go
+++ b/monitorables/ping/api/usecase/ping.go
@@ -4,6 +4,7 @@ package usecase
 
 import (
 	"fmt"
+	"time"
 
 	coreModels "github.com/monitoror/monitoror/models"
 	"github.com/monitoror/monitoror/monitorables/ping/api"
@@ -28,7 +29,12 @@ func (pu *pingUsecase) Ping(params *models.PingParams) (tile *coreModels.Tile, e
 	if err == nil {
 		tile.Status = coreModels.SuccessStatus
 		tile.WithMetrics(coreModels.MillisecondUnit)
-		tile.Metrics.Values = append(tile.Metrics.Values, fmt.Sprintf("%d", ping.Average.Milliseconds()))
+		if ping.Average < time.Millisecond {
+			ms := float64(ping.Average.Nanoseconds()) / float64(time.Millisecond)
+			tile.Metrics.Values = append(tile.Metrics.Values, fmt.Sprintf("%.2f", ms))
+		} else {
+			tile.Metrics.Values = append(tile.Metrics.Values, fmt.Sprintf("%d", ping.Average.Milliseconds()))
+		}
 	} else {
 		tile.Status = coreModels.FailedStatus
 		err = nil

--- a/monitorables/ping/api/usecase/ping_test.go
+++ b/monitorables/ping/api/usecase/ping_test.go
@@ -45,6 +45,31 @@ func TestUsecase_Ping_Success(t *testing.T) {
 	}
 }
 
+func TestUsecase_Ping_SubMillisecond(t *testing.T) {
+	mockRepo := new(mocks.Repository)
+	mockRepo.On("ExecutePing", AnythingOfType("string")).Return(&models.Ping{
+		Average: 500 * time.Microsecond,
+		Min:     500 * time.Microsecond,
+		Max:     500 * time.Microsecond,
+	}, nil)
+	usecase := NewPingUsecase(mockRepo)
+
+	param := &models.PingParams{Hostname: "monitoror.example.com"}
+
+	eTile := coreModels.NewTile(api.PingTileType).WithMetrics(coreModels.MillisecondUnit)
+	eTile.Label = param.Hostname
+	eTile.Status = coreModels.SuccessStatus
+	eTile.Metrics.Values = append(eTile.Metrics.Values, "0.50")
+
+	rTile, err := usecase.Ping(param)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, eTile, rTile)
+		mockRepo.AssertNumberOfCalls(t, "ExecutePing", 1)
+		mockRepo.AssertExpectations(t)
+	}
+}
+
 func TestUsecase_Ping_Fail(t *testing.T) {
 	// Init
 	mockRepo := new(mocks.Repository)


### PR DESCRIPTION
## Summary
- show ping values with two decimals if below 1ms
- test sub-millisecond ping formatting
