### PR TITLE
Add WHOIS domain expiration monitor

### DIFF
--- a/monitorables/monitorables.go
+++ b/monitorables/monitorables.go
@@ -1,9 +1,9 @@
 package monitorables
 
 import (
-       "github.com/monitoror/monitoror/monitorables/azuredevops"
-       "github.com/monitoror/monitoror/monitorables/dns"
-       "github.com/monitoror/monitoror/monitorables/github"
+	"github.com/monitoror/monitoror/monitorables/azuredevops"
+	"github.com/monitoror/monitoror/monitorables/dns"
+	"github.com/monitoror/monitoror/monitorables/github"
 	"github.com/monitoror/monitoror/monitorables/gitlab"
 	"github.com/monitoror/monitoror/monitorables/http"
 	"github.com/monitoror/monitoror/monitorables/jenkins"
@@ -12,6 +12,7 @@ import (
 	"github.com/monitoror/monitoror/monitorables/port"
 	"github.com/monitoror/monitoror/monitorables/ssl"
 	"github.com/monitoror/monitoror/monitorables/travisci"
+	"github.com/monitoror/monitoror/monitorables/whois"
 	"github.com/monitoror/monitoror/store"
 )
 
@@ -29,13 +30,15 @@ func RegisterMonitorables(s *store.Store) {
 	// ------------ PING ------------
 	s.Registry.RegisterMonitorable(ping.NewMonitorable(s))
 	// ------------ PINGDOM ------------
-       s.Registry.RegisterMonitorable(pingdom.NewMonitorable(s))
-       // ------------ PORT ------------
-       s.Registry.RegisterMonitorable(port.NewMonitorable(s))
-       // ------------ DNS ------------
-       s.Registry.RegisterMonitorable(dns.NewMonitorable(s))
-       // ------------ SSL ------------
+	s.Registry.RegisterMonitorable(pingdom.NewMonitorable(s))
+	// ------------ PORT ------------
+	s.Registry.RegisterMonitorable(port.NewMonitorable(s))
+	// ------------ DNS ------------
+	s.Registry.RegisterMonitorable(dns.NewMonitorable(s))
+	// ------------ SSL ------------
 	s.Registry.RegisterMonitorable(ssl.NewMonitorable(s))
+	// ------------ WHOIS ------------
+	s.Registry.RegisterMonitorable(whois.NewMonitorable(s))
 	// ------------ TRAVIS CI ------------
 	s.Registry.RegisterMonitorable(travisci.NewMonitorable(s))
 }

--- a/monitorables/whois/api/delivery/http/handlers.go
+++ b/monitorables/whois/api/delivery/http/handlers.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/delivery"
+	"github.com/monitoror/monitoror/monitorables/whois/api"
+	"github.com/monitoror/monitoror/monitorables/whois/api/models"
+
+	"github.com/labstack/echo/v4"
+)
+
+type WHOISDelivery struct {
+	whoisUsecase api.Usecase
+}
+
+func NewWHOISDelivery(u api.Usecase) *WHOISDelivery { return &WHOISDelivery{u} }
+
+func (h *WHOISDelivery) GetWHOIS(c echo.Context) error {
+	params := &models.WHOISParams{}
+	if err := delivery.BindAndValidateParams(c, params); err != nil {
+		return err
+	}
+
+	tile, err := h.whoisUsecase.WHOIS(params)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, tile)
+}

--- a/monitorables/whois/api/models/params.go
+++ b/monitorables/whois/api/models/params.go
@@ -1,0 +1,12 @@
+//go:build !faker
+
+package models
+
+import "github.com/monitoror/monitoror/internal/pkg/monitorable/params"
+
+type WHOISParams struct {
+	params.Default
+
+	Domain   string `json:"domain" query:"domain" validate:"required"`
+	WarnDays int    `json:"warnDays" query:"warnDays" validate:"gte=0"`
+}

--- a/monitorables/whois/api/models/params_faker.go
+++ b/monitorables/whois/api/models/params_faker.go
@@ -1,0 +1,17 @@
+//go:build faker
+
+package models
+
+import (
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/params"
+	coreModels "github.com/monitoror/monitoror/models"
+)
+
+type WHOISParams struct {
+	params.Default
+
+	Domain   string `json:"domain" query:"domain"`
+	WarnDays int    `json:"warnDays" query:"warnDays"`
+
+	Status coreModels.TileStatus `json:"status" query:"status"`
+}

--- a/monitorables/whois/api/repository.go
+++ b/monitorables/whois/api/repository.go
@@ -1,0 +1,9 @@
+//go:generate mockery --name Repository
+
+package api
+
+import "time"
+
+type Repository interface {
+	DomainExpiration(domain string) (time.Time, error)
+}

--- a/monitorables/whois/api/repository/whois.go
+++ b/monitorables/whois/api/repository/whois.go
@@ -62,12 +62,14 @@ func (r *whoisRepository) DomainExpiration(domain string) (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	re := regexp.MustCompile(`(?i)(expiry|expiration) date:\s*(.+)`) // capture
+	// Look for any expire-related line. Examples include:
+	// "Expiry Date: 2026-06-07" or "Record expires on: Fri Oct 21 05:54:20 2033"
+	re := regexp.MustCompile(`(?i)(?:expiry|expiration|expires?)\s*(?:date|on)?\s*:\s*(.+)`)
 	scanner = bufio.NewScanner(strings.NewReader(out))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if m := re.FindStringSubmatch(line); m != nil {
-			dateStr := strings.TrimSpace(m[2])
+			dateStr := strings.TrimSpace(m[1])
 			layouts := []string{
 				time.RFC3339,
 				"2006-01-02T15:04:05Z",

--- a/monitorables/whois/api/repository/whois.go
+++ b/monitorables/whois/api/repository/whois.go
@@ -1,0 +1,87 @@
+package repository
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/monitoror/monitoror/monitorables/whois/api"
+)
+
+type whoisRepository struct{}
+
+func NewWHOISRepository() api.Repository { return &whoisRepository{} }
+
+func (r *whoisRepository) query(server, query string) (string, error) {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(server, "43"), time.Second*5)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	if _, err = fmt.Fprintf(conn, "%s\r\n", query); err != nil {
+		return "", err
+	}
+	data, err := io.ReadAll(conn)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (r *whoisRepository) DomainExpiration(domain string) (time.Time, error) {
+	parts := strings.Split(domain, ".")
+	if len(parts) < 2 {
+		return time.Time{}, fmt.Errorf("invalid domain")
+	}
+	tld := parts[len(parts)-1]
+
+	res, err := r.query("whois.iana.org", tld)
+	if err != nil {
+		return time.Time{}, err
+	}
+	server := ""
+	scanner := bufio.NewScanner(strings.NewReader(res))
+	for scanner.Scan() {
+		line := strings.ToLower(strings.TrimSpace(scanner.Text()))
+		if strings.HasPrefix(line, "whois:") {
+			server = strings.TrimSpace(scanner.Text()[6:])
+			break
+		}
+	}
+	if server == "" {
+		return time.Time{}, fmt.Errorf("whois server not found")
+	}
+
+	out, err := r.query(server, domain)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	re := regexp.MustCompile(`(?i)(expiry|expiration) date:\s*(.+)`) // capture
+	scanner = bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if m := re.FindStringSubmatch(line); m != nil {
+			dateStr := strings.TrimSpace(m[2])
+			layouts := []string{
+				time.RFC3339,
+				"2006-01-02T15:04:05Z",
+				"2006-01-02 15:04:05Z",
+				"2006-01-02T15:04:05Z07:00",
+				"2006-01-02 15:04:05-07",
+				"2006-01-02",
+			}
+			for _, l := range layouts {
+				if t, e := time.Parse(l, dateStr); e == nil {
+					return t, nil
+				}
+			}
+		}
+	}
+	return time.Time{}, fmt.Errorf("expiration date not found")
+}

--- a/monitorables/whois/api/usecase.go
+++ b/monitorables/whois/api/usecase.go
@@ -1,0 +1,16 @@
+//go:generate mockery --name Usecase
+
+package api
+
+import (
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/whois/api/models"
+)
+
+const (
+	WHOISTileType coreModels.TileType = "WHOIS"
+)
+
+type Usecase interface {
+	WHOIS(params *models.WHOISParams) (*coreModels.Tile, error)
+}

--- a/monitorables/whois/api/usecase/whois.go
+++ b/monitorables/whois/api/usecase/whois.go
@@ -1,0 +1,45 @@
+//go:build !faker
+
+package usecase
+
+import (
+	"fmt"
+	"time"
+
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/whois/api"
+	"github.com/monitoror/monitoror/monitorables/whois/api/models"
+)
+
+type whoisUsecase struct {
+	repository api.Repository
+}
+
+func NewWHOISUsecase(repository api.Repository) api.Usecase {
+	return &whoisUsecase{repository}
+}
+
+func (wu *whoisUsecase) WHOIS(params *models.WHOISParams) (*coreModels.Tile, error) {
+	tile := coreModels.NewTile(api.WHOISTileType)
+	tile.Label = params.Domain
+
+	expiry, err := wu.repository.DomainExpiration(params.Domain)
+	if err != nil {
+		tile.Status = coreModels.FailedStatus
+		tile.Message = err.Error()
+		return tile, nil
+	}
+
+	remaining := int(expiry.Sub(time.Now()).Hours() / 24)
+	if params.WarnDays > 0 && remaining <= params.WarnDays {
+		tile.Status = coreModels.WarningStatus
+	} else {
+		tile.Status = coreModels.SuccessStatus
+	}
+
+	tile.WithMetrics(coreModels.RawUnit)
+	tile.Metrics.Values = []string{fmt.Sprintf("Expires in %d days", remaining)}
+	tile.Message = expiry.Format(time.RFC3339)
+
+	return tile, nil
+}

--- a/monitorables/whois/api/usecase/whois_faker.go
+++ b/monitorables/whois/api/usecase/whois_faker.go
@@ -1,0 +1,63 @@
+//go:build faker
+
+package usecase
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/faker"
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/whois/api"
+	"github.com/monitoror/monitoror/monitorables/whois/api/models"
+	"github.com/monitoror/monitoror/pkg/nonempty"
+)
+
+type whoisUsecase struct {
+	refByDomain map[string]time.Time
+}
+
+var availableStatuses = faker.Statuses{
+	{coreModels.SuccessStatus, time.Second * 30},
+	{coreModels.WarningStatus, time.Second * 30},
+	{coreModels.FailedStatus, time.Second * 30},
+}
+
+func NewWHOISUsecase() api.Usecase { return &whoisUsecase{make(map[string]time.Time)} }
+
+func (wu *whoisUsecase) WHOIS(params *models.WHOISParams) (*coreModels.Tile, error) {
+	tile := coreModels.NewTile(api.WHOISTileType).WithMetrics(coreModels.RawUnit)
+	tile.Label = params.Domain
+
+	status := wu.computeStatus(params.Domain)
+	tile.Status = nonempty.Struct(params.Status, status).(coreModels.TileStatus)
+
+	remaining := wu.computeRemainingDays(params.Domain)
+	tile.Metrics.Values = []string{fmt.Sprintf("Expires in %d days", remaining)}
+	tile.Message = time.Now().AddDate(0, 0, remaining).Format(time.RFC3339)
+
+	return tile, nil
+}
+
+func (wu *whoisUsecase) computeStatus(domain string) coreModels.TileStatus {
+	value, ok := wu.refByDomain[domain]
+	if !ok {
+		wu.refByDomain[domain] = faker.GetRefTime()
+		value = wu.refByDomain[domain]
+	}
+	return faker.ComputeStatus(value, availableStatuses)
+}
+
+func (wu *whoisUsecase) computeRemainingDays(domain string) int {
+	value, ok := wu.refByDomain[domain]
+	if !ok {
+		wu.refByDomain[domain] = faker.GetRefTime()
+		value = wu.refByDomain[domain]
+	}
+	duration := faker.ComputeDuration(value, time.Hour*24*90)
+	remaining := 90 - int(duration.Hours()/24)
+	if remaining == 0 {
+		remaining = 90
+	}
+	return remaining
+}

--- a/monitorables/whois/whois.go
+++ b/monitorables/whois/whois.go
@@ -1,0 +1,60 @@
+//go:build !faker
+
+package whois
+
+import (
+	"github.com/monitoror/monitoror/api/config/versions"
+	pkgMonitorable "github.com/monitoror/monitoror/internal/pkg/monitorable"
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/whois/api"
+	whoisDelivery "github.com/monitoror/monitoror/monitorables/whois/api/delivery/http"
+	whoisModels "github.com/monitoror/monitoror/monitorables/whois/api/models"
+	whoisRepository "github.com/monitoror/monitoror/monitorables/whois/api/repository"
+	whoisUsecase "github.com/monitoror/monitoror/monitorables/whois/api/usecase"
+	"github.com/monitoror/monitoror/registry"
+	"github.com/monitoror/monitoror/store"
+)
+
+type Monitorable struct {
+	store *store.Store
+
+	config map[coreModels.VariantName]*struct{}
+
+	whoisTileEnabler registry.TileEnabler
+}
+
+func NewMonitorable(store *store.Store) *Monitorable {
+	m := &Monitorable{}
+	m.store = store
+	m.config = make(map[coreModels.VariantName]*struct{})
+
+	pkgMonitorable.LoadConfig(&m.config, &struct{}{})
+
+	m.whoisTileEnabler = store.Registry.RegisterTile(api.WHOISTileType, versions.MinimalVersion, m.GetVariantsNames())
+
+	return m
+}
+
+func (m *Monitorable) GetDisplayName() string { return "WHOIS" }
+
+func (m *Monitorable) GetVariantsNames() []coreModels.VariantName {
+	return pkgMonitorable.GetVariantsNames(m.config)
+}
+
+func (m *Monitorable) Validate(variantName coreModels.VariantName) (bool, []error) {
+	if errors := pkgMonitorable.ValidateConfig(m.config[variantName], variantName); errors != nil {
+		return false, errors
+	}
+	return true, nil
+}
+
+func (m *Monitorable) Enable(variantName coreModels.VariantName) {
+	repository := whoisRepository.NewWHOISRepository()
+	usecase := whoisUsecase.NewWHOISUsecase(repository)
+	delivery := whoisDelivery.NewWHOISDelivery(usecase)
+
+	routeGroup := m.store.MonitorableRouter.Group("/whois", variantName)
+	route := routeGroup.GET("/domain", delivery.GetWHOIS)
+
+	m.whoisTileEnabler.Enable(variantName, &whoisModels.WHOISParams{}, route.Path)
+}

--- a/monitorables/whois/whois_faker.go
+++ b/monitorables/whois/whois_faker.go
@@ -1,0 +1,42 @@
+//go:build faker
+
+package whois
+
+import (
+	"github.com/monitoror/monitoror/api/config/versions"
+	"github.com/monitoror/monitoror/internal/pkg/monitorable"
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/whois/api"
+	whoisDelivery "github.com/monitoror/monitoror/monitorables/whois/api/delivery/http"
+	whoisModels "github.com/monitoror/monitoror/monitorables/whois/api/models"
+	whoisUsecase "github.com/monitoror/monitoror/monitorables/whois/api/usecase"
+	"github.com/monitoror/monitoror/registry"
+	"github.com/monitoror/monitoror/store"
+)
+
+type Monitorable struct {
+	monitorable.DefaultMonitorableFaker
+
+	store *store.Store
+
+	whoisTileEnabler registry.TileEnabler
+}
+
+func NewMonitorable(store *store.Store) *Monitorable {
+	m := &Monitorable{}
+	m.store = store
+	m.whoisTileEnabler = store.Registry.RegisterTile(api.WHOISTileType, versions.MinimalVersion, m.GetVariantsNames())
+	return m
+}
+
+func (m *Monitorable) GetDisplayName() string { return "WHOIS" }
+
+func (m *Monitorable) Enable(variantName coreModels.VariantName) {
+	usecase := whoisUsecase.NewWHOISUsecase()
+	delivery := whoisDelivery.NewWHOISDelivery(usecase)
+
+	routeGroup := m.store.MonitorableRouter.Group("/whois", variantName)
+	route := routeGroup.GET("/domain", delivery.GetWHOIS)
+
+	m.whoisTileEnabler.Enable(variantName, &whoisModels.WHOISParams{}, route.Path)
+}


### PR DESCRIPTION
## Summary
- add WHOIS monitorable to check domain expiry
- expose `/whois/domain` endpoint
- allow warning based on remaining days
