### PR TITLE
Add RTSP monitorable

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -172,6 +172,17 @@
             </ul>
           </li>
           <li>
+            <a href="#rtsp">
+              <svg class="m-documentation--menu-icon" xmlns="http://www.w3.org/2000/svg">
+                <use xlink:href="/assets/images/icons.svg#rtsp"/>
+              </svg>
+              RTSP
+            </a>
+            <ul>
+              <li><a href="#tile-rtsp">RTSP</a></li>
+            </ul>
+          </li>
+          <li>
             <a href="#travis-ci">
               <svg class="m-documentation--menu-icon" xmlns="http://www.w3.org/2000/svg">
                 <use xlink:href="/assets/images/icons.svg#travis-ci"/>
@@ -333,6 +344,26 @@
             </svg>
           </span>
         </a>
+        <a href="#rtsp" class="m-documentation-card">
+          <span class="m-documentation-card--mask">
+            <span class="m-documentation-card--title">RTSP</span>
+
+            <svg class="m-documentation-card--icon" xmlns="http://www.w3.org/2000/svg">
+              <use xlink:href="/assets/images/icons.svg#rtsp"/>
+            </svg>
+          </span>
+        </a>
+          <li>
+            <a href="#rtsp">
+              <svg class="m-documentation--menu-icon" xmlns="http://www.w3.org/2000/svg">
+                <use xlink:href="/assets/images/icons.svg#rtsp"/>
+              </svg>
+              RTSP
+            </a>
+            <ul>
+              <li><a href="#tile-rtsp">RTSP</a></li>
+            </ul>
+          </li>
         <a href="#travis-ci" class="m-documentation-card">
           <span class="m-documentation-card--mask">
             <span class="m-documentation-card--title">Travis CI</span>
@@ -2383,6 +2414,147 @@ MO_MONITORABLE_PORT_TIMEOUT=1000
       </div>
     </div>
 <p>The tile message reports if the port responded to the payload and the metrics display the response time in milliseconds.</p>
+
+    <div class="m-documentation--block">
+    <div class="m-documentation--block">
+      <svg class="m-documentation--tile-icon" xmlns="http://www.w3.org/2000/svg">
+        <use xlink:href="/assets/images/icons.svg#rtsp"/>
+      </svg>
+
+      <h3 id="rtsp">RTSP</h3>
+
+      <p>
+        Authenticate to an RTSP server using digest authentication.
+      </p>
+
+      <h5 class="m-documentation--configuration-side-title">Core configuration</h5>
+
+      <dl>
+        <dt><code>MO_MONITORABLE_RTSP_TIMEOUT</code> <code class="type">number</code></dt>
+        <dd>
+          Timeout in milliseconds before returning error <br>
+          <span class="tag">Default:</span> <code>2000</code>
+        </dd>
+      </dl>
+
+      <p class="success-block">
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <use xlink:href="/assets/images/icons.svg#configuration-variants"/>
+        </svg>
+        <a href="#configuration-variants">Configuration Variants</a> are available for RTSP
+      </p>
+
+      <pre class="example"><code>
+MO_MONITORABLE_RTSP_TIMEOUT=2000
+      </code></pre>
+
+      <h4 id="tile-rtsp">RTSP</h4>
+
+      <p>
+        Try to authenticate using RTSP Digest with provided credentials.
+      </p>
+
+      <h5 class="m-documentation--configuration-side-title">UI configuration</h5>
+
+      <dl>
+        <dt><code>hostname</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>Hostname of the RTSP server</dd>
+        <dt><code>port</code> <code class="type">number</code> <span class="required">required</span></dt>
+        <dd>TCP port of the RTSP server</dd>
+        <dt><code>path</code> <code class="type">string</code></dt>
+        <dd>Stream path to authenticate (default <code>/</code>)</dd>
+        <dt><code>username</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>Username for authentication</dd>
+        <dt><code>password</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>Password for authentication</dd>
+        <dt><code>method</code> <code class="type">string</code></dt>
+        <dd>RTSP method used for requests. Default is <code>OPTIONS</code>.</dd>
+      </dl>
+
+      <div class="m-documentation--example-and-demo">
+        <pre class="example"><code class="language-json">
+{
+  "type": "RTSP",
+  "params": {
+    "hostname": "camera.local",
+    "port": 554,
+    "path": "/",
+    "username": "admin",
+    "password": "password"
+  }
+}
+        </code></pre>
+
+        <div class="m-documentation--demo">
+          <div class="m-documentation--demo-tile">
+            <div class="m-documentation--demo-label">camera.local:554</div>
+            <svg class="m-documentation--demo-icon" xmlns="http://www.w3.org/2000/svg">
+              <use xlink:href="/assets/images/icons.svg#rtsp"/>
+            </svg>
+          </div>
+          <div class="m-documentation--demo-switch">
+            <label class="m-documentation--demo-switch-label m-documentation--demo-switch-succeeded">
+              <input data-state-switch name="rtsp-state" type="radio" value="succeeded">
+              Success
+            </label>
+            <label class="m-documentation--demo-switch-label m-documentation--demo-switch-error">
+              <input data-state-switch name="rtsp-state" type="radio" value="error">
+              Error
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+      <svg class="m-documentation--tile-icon" xmlns="http://www.w3.org/2000/svg">
+        <use xlink:href="/assets/images/icons.svg#rtsp"/>
+      </svg>
+
+      <h3 id="rtsp">RTSP</h3>
+
+      <p>
+        Authenticate to an RTSP server using digest authentication.
+      </p>
+
+      <h5 class="m-documentation--configuration-side-title">Core configuration</h5>
+
+      <dl>
+        <dt><code>MO_MONITORABLE_RTSP_TIMEOUT</code> <code class="type">number</code></dt>
+        <dd>
+          Timeout in milliseconds before returning error <br>
+          <span class="tag">Default:</span> <code>2000</code>
+        </dd>
+      </dl>
+
+      <p class="success-block">
+        <svg xmlns="http://www.w3.org/2000/svg">
+          <use xlink:href="/assets/images/icons.svg#configuration-variants"/>
+        </svg>
+        <a href="#configuration-variants">Configuration Variants</a> are available for RTSP
+      </p>
+
+      <pre class="example"><code>
+MO_MONITORABLE_RTSP_TIMEOUT=2000
+      </code></pre>
+
+      <h4 id="tile-rtsp">RTSP</h4>
+
+      <p>
+        Try to authenticate using RTSP Digest with provided credentials.
+      </p>
+
+      <h5 class="m-documentation--configuration-side-title">UI configuration</h5>
+
+      <dl>
+        <dt><code>hostname</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>Hostname of the RTSP server</dd>
+        <dt><code>port</code> <code class="type">number</code> <span class="required">required</span></dt>
+        <dd>TCP port of the RTSP server</dd>
+        <dt><code>path</code> <code class="type">string</code></dt>
+        <dd>Stream path to authenticate (default <code>/</code>)</dd>
+        <dt><code>username</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>Username for authentication</dd>
+        <dt><code>password</code> <code class="type">string</code> <span class="required">required</span></dt>
+        <dd>Password for authentication</dd>
 
     <div class="m-documentation--block">
       <svg class="m-documentation--tile-icon" xmlns="http://www.w3.org/2000/svg">

--- a/monitorables/monitorables.go
+++ b/monitorables/monitorables.go
@@ -10,6 +10,7 @@ import (
 	"github.com/monitoror/monitoror/monitorables/ping"
 	"github.com/monitoror/monitoror/monitorables/pingdom"
 	"github.com/monitoror/monitoror/monitorables/port"
+	"github.com/monitoror/monitoror/monitorables/rtsp"
 	"github.com/monitoror/monitoror/monitorables/ssl"
 	"github.com/monitoror/monitoror/monitorables/travisci"
 	"github.com/monitoror/monitoror/monitorables/whois"
@@ -33,6 +34,8 @@ func RegisterMonitorables(s *store.Store) {
 	s.Registry.RegisterMonitorable(pingdom.NewMonitorable(s))
 	// ------------ PORT ------------
 	s.Registry.RegisterMonitorable(port.NewMonitorable(s))
+	// ------------ RTSP ------------
+	s.Registry.RegisterMonitorable(rtsp.NewMonitorable(s))
 	// ------------ DNS ------------
 	s.Registry.RegisterMonitorable(dns.NewMonitorable(s))
 	// ------------ SSL ------------

--- a/monitorables/rtsp/api/delivery/http/handlers.go
+++ b/monitorables/rtsp/api/delivery/http/handlers.go
@@ -1,0 +1,31 @@
+package http
+
+import (
+	"net/http"
+
+	delivery "github.com/monitoror/monitoror/internal/pkg/monitorable/delivery"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api/models"
+
+	echo "github.com/labstack/echo/v4"
+)
+
+type RTSPDelivery struct {
+	usecase api.Usecase
+}
+
+func NewRTSPDelivery(u api.Usecase) *RTSPDelivery { return &RTSPDelivery{u} }
+
+func (h *RTSPDelivery) GetRTSP(c echo.Context) error {
+	params := &models.RTSPParams{}
+	if err := delivery.BindAndValidateParams(c, params); err != nil {
+		return err
+	}
+
+	tile, err := h.usecase.RTSP(params)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, tile)
+}

--- a/monitorables/rtsp/api/models/rtspparams.go
+++ b/monitorables/rtsp/api/models/rtspparams.go
@@ -1,0 +1,23 @@
+//go:build !faker
+
+package models
+
+import "github.com/monitoror/monitoror/internal/pkg/monitorable/params"
+
+type RTSPParams struct {
+	params.Default
+
+	Hostname string `json:"hostname" query:"hostname" validate:"required"`
+	Port     int    `json:"port" query:"port" validate:"required,gt=0"`
+	Path     string `json:"path,omitempty" query:"path"`
+	Username string `json:"username" query:"username" validate:"required"`
+	Password string `json:"password" query:"password" validate:"required"`
+	Method   string `json:"method,omitempty" query:"method"`
+}
+
+func (p *RTSPParams) GetMethod() string {
+	if p.Method == "" {
+		return "OPTIONS"
+	}
+	return p.Method
+}

--- a/monitorables/rtsp/api/models/rtspparams_faker.go
+++ b/monitorables/rtsp/api/models/rtspparams_faker.go
@@ -1,0 +1,28 @@
+//go:build faker
+
+package models
+
+import (
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/params"
+	coreModels "github.com/monitoror/monitoror/models"
+)
+
+type RTSPParams struct {
+	params.Default
+
+	Hostname string `json:"hostname" query:"hostname"`
+	Port     int    `json:"port" query:"port"`
+	Path     string `json:"path,omitempty" query:"path"`
+	Username string `json:"username" query:"username"`
+	Password string `json:"password" query:"password"`
+	Method   string `json:"method,omitempty" query:"method"`
+
+	Status coreModels.TileStatus `json:"status" query:"status"`
+}
+
+func (p *RTSPParams) GetMethod() string {
+	if p.Method == "" {
+		return "OPTIONS"
+	}
+	return p.Method
+}

--- a/monitorables/rtsp/api/repository.go
+++ b/monitorables/rtsp/api/repository.go
@@ -1,0 +1,11 @@
+//go:generate mockery --name Repository
+
+package api
+
+import "time"
+
+type (
+	Repository interface {
+		Authenticate(hostname string, port int, path, method, username, password string) (bool, time.Duration, error)
+	}
+)

--- a/monitorables/rtsp/api/repository/rtsp.go
+++ b/monitorables/rtsp/api/repository/rtsp.go
@@ -1,0 +1,113 @@
+package repository
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/monitoror/monitoror/monitorables/rtsp/api"
+	"github.com/monitoror/monitoror/monitorables/rtsp/config"
+	pkgNet "github.com/monitoror/monitoror/pkg/net"
+)
+
+type rtspRepository struct {
+	config *config.RTSP
+	dialer pkgNet.Dialer
+}
+
+func NewRTSPRepository(conf *config.RTSP) api.Repository {
+	timeout := time.Millisecond * time.Duration(conf.Timeout)
+	return &rtspRepository{conf, &net.Dialer{Timeout: timeout}}
+}
+
+func parseDigest(header string) map[string]string {
+	res := map[string]string{}
+	header = strings.TrimSpace(header)
+	if strings.HasPrefix(strings.ToLower(header), "digest") {
+		header = strings.TrimSpace(header[len("digest"):])
+	}
+	parts := strings.Split(header, ",")
+	for _, p := range parts {
+		kv := strings.SplitN(strings.TrimSpace(p), "=", 2)
+		if len(kv) == 2 {
+			res[strings.ToLower(strings.TrimSpace(kv[0]))] = strings.Trim(kv[1], "\"")
+		}
+	}
+	return res
+}
+
+func computeDigest(username, realm, password, method, uri, nonce string) string {
+	ha1 := md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", username, realm, password)))
+	ha2 := md5.Sum([]byte(fmt.Sprintf("%s:%s", method, uri)))
+	resp := md5.Sum([]byte(fmt.Sprintf("%s:%s:%s", hex.EncodeToString(ha1[:]), nonce, hex.EncodeToString(ha2[:]))))
+	return hex.EncodeToString(resp[:])
+}
+
+func (r *rtspRepository) Authenticate(hostname string, port int, path, method, username, password string) (bool, time.Duration, error) {
+	start := time.Now()
+	if path == "" {
+		path = "/"
+	}
+	if method == "" {
+		method = "OPTIONS"
+	}
+	target := fmt.Sprintf("%s:%d", hostname, port)
+	conn, err := r.dialer.Dial("tcp", target)
+	if err != nil {
+		return false, time.Since(start), err
+	}
+	if conn == nil {
+		return false, time.Since(start), fmt.Errorf("no connection")
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(time.Millisecond * time.Duration(r.config.Timeout))
+	_ = conn.SetDeadline(deadline)
+
+	uri := fmt.Sprintf("rtsp://%s:%d%s", hostname, port, path)
+	req1 := fmt.Sprintf("%s %s RTSP/1.0\r\nCSeq: 1\r\n\r\n", method, uri)
+	if _, err = conn.Write([]byte(req1)); err != nil {
+		return false, time.Since(start), err
+	}
+
+	buf := make([]byte, 4096)
+	n, err := conn.Read(buf)
+	if err != nil && !strings.Contains(err.Error(), "EOF") {
+		return false, time.Since(start), err
+	}
+	resp := string(buf[:n])
+	var authHeader string
+	for _, line := range strings.Split(resp, "\r\n") {
+		if strings.HasPrefix(strings.ToLower(line), "www-authenticate:") {
+			authHeader = strings.TrimSpace(line[len("WWW-Authenticate:"):])
+			break
+		}
+	}
+	if authHeader == "" {
+		return false, time.Since(start), fmt.Errorf("no auth header")
+	}
+	params := parseDigest(authHeader)
+	realm := params["realm"]
+	nonce := params["nonce"]
+	response := computeDigest(username, realm, password, method, uri, nonce)
+
+	req2 := fmt.Sprintf("%s %s RTSP/1.0\r\nCSeq: 2\r\nAuthorization: Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", uri=\"%s\", response=\"%s\"\r\n\r\n",
+		method, uri, username, realm, nonce, uri, response)
+	if _, err = conn.Write([]byte(req2)); err != nil {
+		return false, time.Since(start), err
+	}
+
+	n, err = conn.Read(buf)
+	duration := time.Since(start)
+	if err != nil && !strings.Contains(err.Error(), "EOF") {
+		return false, duration, err
+	}
+	resp2 := string(buf[:n])
+	if strings.HasPrefix(resp2, "RTSP/1.0 200") {
+		return true, duration, nil
+	}
+	return false, duration, nil
+}

--- a/monitorables/rtsp/api/repository/rtsp_test.go
+++ b/monitorables/rtsp/api/repository/rtsp_test.go
@@ -1,0 +1,65 @@
+package repository
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	rtspConfig "github.com/monitoror/monitoror/monitorables/rtsp/config"
+	pkgNet "github.com/monitoror/monitoror/pkg/net"
+	"github.com/monitoror/monitoror/pkg/net/mocks"
+
+	"github.com/stretchr/testify/assert"
+	. "github.com/stretchr/testify/mock"
+)
+
+func initRepository(t *testing.T, dialer pkgNet.Dialer) *rtspRepository {
+	conf := &rtspConfig.RTSP{Timeout: 1000}
+	repo := NewRTSPRepository(conf)
+	r, ok := repo.(*rtspRepository)
+	if assert.True(t, ok) {
+		r.dialer = dialer
+		return r
+	}
+	return nil
+}
+
+func md5Hex(b []byte) string { return hex.EncodeToString(md5.Sum(b)[:]) }
+
+func expectedDigest(user, realm, pass, method, uri, nonce string) string {
+	ha1 := md5Hex([]byte(fmt.Sprintf("%s:%s:%s", user, realm, pass)))
+	ha2 := md5Hex([]byte(fmt.Sprintf("%s:%s", method, uri)))
+	final := md5Hex([]byte(fmt.Sprintf("%s:%s:%s", ha1, nonce, ha2)))
+	return final
+}
+
+func TestRepository_Authenticate_Digest(t *testing.T) {
+	challenge := "RTSP/1.0 401 Unauthorized\r\nCSeq: 1\r\nWWW-Authenticate: Digest realm=\"realm\", nonce=\"nonce\"\r\n\r\n"
+	success := "RTSP/1.0 200 OK\r\nCSeq: 2\r\n\r\n"
+
+	mockConn := new(mocks.Conn)
+	mockConn.On("Close").Return(nil)
+	mockConn.On("SetDeadline", AnythingOfType("time.Time")).Return(nil)
+	mockConn.On("Write", Anything).Return(func(b []byte) (int, error) { return len(b), nil }).Once()
+	mockConn.On("Read", Anything).Run(func(args Arguments) { copy(args.Get(0).([]byte), []byte(challenge)) }).Return(len(challenge), nil).Once()
+
+	var second []byte
+	mockConn.On("Write", Anything).Return(func(b []byte) (int, error) { second = append([]byte(nil), b...); return len(b), nil }).Once()
+	mockConn.On("Read", Anything).Run(func(args Arguments) { copy(args.Get(0).([]byte), []byte(success)) }).Return(len(success), nil).Once()
+
+	mockDialer := new(mocks.Dialer)
+	mockDialer.On("Dial", AnythingOfType("string"), AnythingOfType("string")).Return(mockConn, nil)
+
+	repo := initRepository(t, mockDialer)
+	if repo != nil {
+		ok, dur, err := repo.Authenticate("test", 554, "/", "OPTIONS", "user", "pass")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+		assert.NotZero(t, dur)
+
+		digest := expectedDigest("user", "realm", "pass", "OPTIONS", "rtsp://test:554/", "nonce")
+		assert.Contains(t, string(second), fmt.Sprintf("response=\"%s\"", digest))
+	}
+}

--- a/monitorables/rtsp/api/usecase.go
+++ b/monitorables/rtsp/api/usecase.go
@@ -1,0 +1,18 @@
+//go:generate mockery --name Usecase
+
+package api
+
+import (
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api/models"
+)
+
+const (
+	RTSPTileType coreModels.TileType = "RTSP"
+)
+
+type (
+	Usecase interface {
+		RTSP(params *models.RTSPParams) (*coreModels.Tile, error)
+	}
+)

--- a/monitorables/rtsp/api/usecase/rtsp.go
+++ b/monitorables/rtsp/api/usecase/rtsp.go
@@ -1,0 +1,41 @@
+//go:build !faker
+
+package usecase
+
+import (
+	"fmt"
+
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api/models"
+)
+
+type rtspUsecase struct {
+	repository api.Repository
+}
+
+func NewRTSPUsecase(repo api.Repository) api.Usecase { return &rtspUsecase{repo} }
+
+func (u *rtspUsecase) RTSP(params *models.RTSPParams) (*coreModels.Tile, error) {
+	tile := coreModels.NewTile(api.RTSPTileType)
+	tile.Label = fmt.Sprintf("%s:%d", params.Hostname, params.Port)
+
+	success, duration, err := u.repository.Authenticate(params.Hostname, params.Port, params.Path, params.GetMethod(), params.Username, params.Password)
+	if err != nil {
+		tile.Status = coreModels.FailedStatus
+		return tile, nil
+	}
+
+	if success {
+		tile.Status = coreModels.SuccessStatus
+		tile.Message = "authenticated"
+	} else {
+		tile.Status = coreModels.FailedStatus
+		tile.Message = "authentication failed"
+	}
+
+	tile.WithMetrics(coreModels.MillisecondUnit)
+	tile.Metrics.Values = []string{fmt.Sprintf("%d", duration.Milliseconds())}
+
+	return tile, nil
+}

--- a/monitorables/rtsp/api/usecase/rtsp_faker.go
+++ b/monitorables/rtsp/api/usecase/rtsp_faker.go
@@ -1,0 +1,43 @@
+//go:build faker
+
+package usecase
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/monitoror/monitoror/internal/pkg/monitorable/faker"
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api/models"
+	"github.com/monitoror/monitoror/pkg/nonempty"
+)
+
+type rtspUsecase struct {
+	timeRefByHost map[string]time.Time
+}
+
+var availableStatuses = faker.Statuses{
+	{coreModels.SuccessStatus, time.Second * 30},
+	{coreModels.FailedStatus, time.Second * 30},
+}
+
+func NewRTSPUsecase(_ api.Repository) api.Usecase { return &rtspUsecase{make(map[string]time.Time)} }
+
+func (u *rtspUsecase) RTSP(params *models.RTSPParams) (*coreModels.Tile, error) {
+	tile := coreModels.NewTile(api.RTSPTileType)
+	tile.Label = fmt.Sprintf("%s:%d", params.Hostname, params.Port)
+
+	tile.Status = nonempty.Struct(params.Status, u.computeStatus(params)).(coreModels.TileStatus)
+	return tile, nil
+}
+
+func (u *rtspUsecase) computeStatus(params *models.RTSPParams) coreModels.TileStatus {
+	key := fmt.Sprintf("%s:%d", params.Hostname, params.Port)
+	value, ok := u.timeRefByHost[key]
+	if !ok {
+		u.timeRefByHost[key] = faker.GetRefTime()
+		value = u.timeRefByHost[key]
+	}
+	return faker.ComputeStatus(value, availableStatuses)
+}

--- a/monitorables/rtsp/config/config.go
+++ b/monitorables/rtsp/config/config.go
@@ -1,0 +1,11 @@
+package config
+
+type (
+	RTSP struct {
+		Timeout int `validate:"gte=0"`
+	}
+)
+
+var Default = &RTSP{
+	Timeout: 2000,
+}

--- a/monitorables/rtsp/rtsp.go
+++ b/monitorables/rtsp/rtsp.go
@@ -1,0 +1,66 @@
+//go:build !faker
+
+package rtsp
+
+import (
+	"github.com/monitoror/monitoror/api/config/versions"
+	pkgMonitorable "github.com/monitoror/monitoror/internal/pkg/monitorable"
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api"
+	rtspDelivery "github.com/monitoror/monitoror/monitorables/rtsp/api/delivery/http"
+	rtspModels "github.com/monitoror/monitoror/monitorables/rtsp/api/models"
+	rtspRepository "github.com/monitoror/monitoror/monitorables/rtsp/api/repository"
+	rtspUsecase "github.com/monitoror/monitoror/monitorables/rtsp/api/usecase"
+	rtspConfig "github.com/monitoror/monitoror/monitorables/rtsp/config"
+	"github.com/monitoror/monitoror/registry"
+	"github.com/monitoror/monitoror/store"
+)
+
+type Monitorable struct {
+	store *store.Store
+
+	config map[coreModels.VariantName]*rtspConfig.RTSP
+
+	rtspTileEnabler registry.TileEnabler
+}
+
+func NewMonitorable(store *store.Store) *Monitorable {
+	m := &Monitorable{}
+	m.store = store
+	m.config = make(map[coreModels.VariantName]*rtspConfig.RTSP)
+
+	pkgMonitorable.LoadConfig(&m.config, rtspConfig.Default)
+
+	m.rtspTileEnabler = store.Registry.RegisterTile(api.RTSPTileType, versions.MinimalVersion, m.GetVariantsNames())
+
+	return m
+}
+
+func (m *Monitorable) GetDisplayName() string { return "RTSP" }
+
+func (m *Monitorable) GetVariantsNames() []coreModels.VariantName {
+	return pkgMonitorable.GetVariantsNames(m.config)
+}
+
+func (m *Monitorable) Validate(variantName coreModels.VariantName) (bool, []error) {
+	conf := m.config[variantName]
+
+	if errors := pkgMonitorable.ValidateConfig(conf, variantName); errors != nil {
+		return false, errors
+	}
+
+	return true, nil
+}
+
+func (m *Monitorable) Enable(variantName coreModels.VariantName) {
+	conf := m.config[variantName]
+
+	repository := rtspRepository.NewRTSPRepository(conf)
+	usecase := rtspUsecase.NewRTSPUsecase(repository)
+	delivery := rtspDelivery.NewRTSPDelivery(usecase)
+
+	routeGroup := m.store.MonitorableRouter.Group("/rtsp", variantName)
+	route := routeGroup.GET("/rtsp", delivery.GetRTSP)
+
+	m.rtspTileEnabler.Enable(variantName, &rtspModels.RTSPParams{}, route.Path)
+}

--- a/monitorables/rtsp/rtsp_faker.go
+++ b/monitorables/rtsp/rtsp_faker.go
@@ -1,0 +1,44 @@
+//go:build faker
+
+package rtsp
+
+import (
+	"github.com/monitoror/monitoror/api/config/versions"
+	"github.com/monitoror/monitoror/internal/pkg/monitorable"
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/rtsp/api"
+	rtspDelivery "github.com/monitoror/monitoror/monitorables/rtsp/api/delivery/http"
+	rtspModels "github.com/monitoror/monitoror/monitorables/rtsp/api/models"
+	rtspUsecase "github.com/monitoror/monitoror/monitorables/rtsp/api/usecase"
+	"github.com/monitoror/monitoror/registry"
+	"github.com/monitoror/monitoror/store"
+)
+
+type Monitorable struct {
+	monitorable.DefaultMonitorableFaker
+
+	store *store.Store
+
+	rtspTileEnabler registry.TileEnabler
+}
+
+func NewMonitorable(store *store.Store) *Monitorable {
+	m := &Monitorable{}
+	m.store = store
+
+	m.rtspTileEnabler = store.Registry.RegisterTile(api.RTSPTileType, versions.MinimalVersion, m.GetVariantsNames())
+
+	return m
+}
+
+func (m *Monitorable) GetDisplayName() string { return "RTSP" }
+
+func (m *Monitorable) Enable(variantName coreModels.VariantName) {
+	usecase := rtspUsecase.NewRTSPUsecase(nil)
+	delivery := rtspDelivery.NewRTSPDelivery(usecase)
+
+	routeGroup := m.store.MonitorableRouter.Group("/rtsp", variantName)
+	route := routeGroup.GET("/rtsp", delivery.GetRTSP)
+
+	m.rtspTileEnabler.Enable(variantName, &rtspModels.RTSPParams{}, route.Path)
+}


### PR DESCRIPTION
## Summary
- add new RTSP monitorable modeled on PORT
- implement RTSP repository with digest authentication
- expose RTSP usecase and delivery
- register RTSP monitorable
- document the RTSP tile
- tests for digest auth negotiation
