### PR TITLE
Add WHOIS display flag

### DIFF
--- a/monitorables/whois/api/models/params.go
+++ b/monitorables/whois/api/models/params.go
@@ -9,4 +9,5 @@ type WHOISParams struct {
 
 	Domain   string `json:"domain" query:"domain" validate:"required"`
 	WarnDays int    `json:"warnDays" query:"warnDays" validate:"gte=0"`
+	Display  string `json:"display" query:"display"`
 }

--- a/monitorables/whois/api/models/params_faker.go
+++ b/monitorables/whois/api/models/params_faker.go
@@ -12,6 +12,7 @@ type WHOISParams struct {
 
 	Domain   string `json:"domain" query:"domain"`
 	WarnDays int    `json:"warnDays" query:"warnDays"`
+	Display  string `json:"display" query:"display"`
 
 	Status coreModels.TileStatus `json:"status" query:"status"`
 }

--- a/monitorables/whois/api/repository.go
+++ b/monitorables/whois/api/repository.go
@@ -5,5 +5,5 @@ package api
 import "time"
 
 type Repository interface {
-	DomainExpiration(domain string) (time.Time, error)
+	DomainExpiration(domain string) (time.Time, string, error)
 }

--- a/monitorables/whois/api/repository/whois.go
+++ b/monitorables/whois/api/repository/whois.go
@@ -33,16 +33,16 @@ func (r *whoisRepository) query(server, query string) (string, error) {
 	return string(data), nil
 }
 
-func (r *whoisRepository) DomainExpiration(domain string) (time.Time, error) {
+func (r *whoisRepository) DomainExpiration(domain string) (time.Time, string, error) {
 	parts := strings.Split(domain, ".")
 	if len(parts) < 2 {
-		return time.Time{}, fmt.Errorf("invalid domain")
+		return time.Time{}, "", fmt.Errorf("invalid domain")
 	}
 	tld := parts[len(parts)-1]
 
 	res, err := r.query("whois.iana.org", tld)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, "", err
 	}
 	server := ""
 	scanner := bufio.NewScanner(strings.NewReader(res))
@@ -54,12 +54,12 @@ func (r *whoisRepository) DomainExpiration(domain string) (time.Time, error) {
 		}
 	}
 	if server == "" {
-		return time.Time{}, fmt.Errorf("whois server not found")
+		return time.Time{}, "", fmt.Errorf("whois server not found")
 	}
 
 	out, err := r.query(server, domain)
 	if err != nil {
-		return time.Time{}, err
+		return time.Time{}, "", err
 	}
 
 	// Look for any expire-related line. Examples include:
@@ -83,10 +83,10 @@ func (r *whoisRepository) DomainExpiration(domain string) (time.Time, error) {
 			}
 			for _, l := range layouts {
 				if t, err := time.Parse(l, dateStr); err == nil {
-					return t.UTC(), nil // normalise to UTC
+					return t.UTC(), out, nil // normalise to UTC
 				}
 			}
 		}
 	}
-	return time.Time{}, fmt.Errorf("expiration date not found")
+	return time.Time{}, out, fmt.Errorf("expiration date not found")
 }

--- a/monitorables/whois/api/usecase/message.go
+++ b/monitorables/whois/api/usecase/message.go
@@ -1,0 +1,48 @@
+package usecase
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+func buildMessage(display, domain string, expiry time.Time, raw string) string {
+	d := strings.TrimSpace(strings.ToLower(display))
+
+	if d == "" || d == "none" {
+		return ""
+	}
+
+	if d == "full" {
+		return fmt.Sprintf("Domain: %s / Expiration: %s", domain, expiry.Format(time.RFC3339))
+	}
+
+	parts := []string{}
+	for _, field := range strings.Split(display, ",") {
+		f := strings.TrimSpace(strings.ToLower(field))
+		switch f {
+		case "domain":
+			parts = append(parts, domain)
+		case "expiration", "expiry", "expires":
+			parts = append(parts, expiry.Format(time.RFC3339))
+		default:
+			if f == "" {
+				continue
+			}
+			if re, err := regexp.Compile(field); err == nil {
+				if m := re.FindStringSubmatch(raw); m != nil {
+					if len(m) > 1 {
+						parts = append(parts, m[1])
+					} else {
+						parts = append(parts, m[0])
+					}
+				} else {
+					parts = append(parts, "поле не найдено")
+				}
+			}
+		}
+	}
+
+	return strings.Join(parts, " / ")
+}

--- a/monitorables/whois/api/usecase/whois.go
+++ b/monitorables/whois/api/usecase/whois.go
@@ -23,7 +23,7 @@ func (wu *whoisUsecase) WHOIS(params *models.WHOISParams) (*coreModels.Tile, err
 	tile := coreModels.NewTile(api.WHOISTileType)
 	tile.Label = params.Domain
 
-	expiry, err := wu.repository.DomainExpiration(params.Domain)
+	expiry, raw, err := wu.repository.DomainExpiration(params.Domain)
 	if err != nil {
 		tile.Status = coreModels.FailedStatus
 		tile.Message = err.Error()
@@ -39,7 +39,7 @@ func (wu *whoisUsecase) WHOIS(params *models.WHOISParams) (*coreModels.Tile, err
 
 	tile.WithMetrics(coreModels.RawUnit)
 	tile.Metrics.Values = []string{fmt.Sprintf("Expires in %d days", remaining)}
-	tile.Message = expiry.Format(time.RFC3339)
+	tile.Message = buildMessage(params.Display, params.Domain, expiry, raw)
 
 	return tile, nil
 }

--- a/monitorables/whois/api/usecase/whois_faker.go
+++ b/monitorables/whois/api/usecase/whois_faker.go
@@ -33,8 +33,10 @@ func (wu *whoisUsecase) WHOIS(params *models.WHOISParams) (*coreModels.Tile, err
 	tile.Status = nonempty.Struct(params.Status, status).(coreModels.TileStatus)
 
 	remaining := wu.computeRemainingDays(params.Domain)
+	expiry := time.Now().AddDate(0, 0, remaining)
 	tile.Metrics.Values = []string{fmt.Sprintf("Expires in %d days", remaining)}
-	tile.Message = time.Now().AddDate(0, 0, remaining).Format(time.RFC3339)
+	raw := fmt.Sprintf("Domain Name: %s\nExpiry Date: %s", params.Domain, expiry.Format(time.RFC3339))
+	tile.Message = buildMessage(params.Display, params.Domain, expiry, raw)
 
 	return tile, nil
 }

--- a/monitorables/whois/api/usecase/whois_test.go
+++ b/monitorables/whois/api/usecase/whois_test.go
@@ -1,0 +1,47 @@
+package usecase
+
+import (
+	"testing"
+	"time"
+
+	coreModels "github.com/monitoror/monitoror/models"
+	"github.com/monitoror/monitoror/monitorables/whois/api/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeRepo struct {
+	expiry time.Time
+	raw    string
+	err    error
+}
+
+func (f *fakeRepo) DomainExpiration(domain string) (time.Time, string, error) {
+	return f.expiry, f.raw, f.err
+}
+
+func TestWHOIS_DisplayDomain(t *testing.T) {
+	expiry := time.Now().Add(24 * time.Hour)
+	repo := &fakeRepo{expiry: expiry, raw: "Domain Name: example.com"}
+	usecase := NewWHOISUsecase(repo)
+
+	params := &models.WHOISParams{Domain: "example.com", Display: "domain"}
+
+	tile, err := usecase.WHOIS(params)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "example.com", tile.Message)
+		assert.Equal(t, coreModels.SuccessStatus, tile.Status)
+	}
+}
+
+func TestWHOIS_DisplayRegexNotFound(t *testing.T) {
+	expiry := time.Now().Add(24 * time.Hour)
+	repo := &fakeRepo{expiry: expiry, raw: "Domain Name: example.com"}
+	usecase := NewWHOISUsecase(repo)
+
+	params := &models.WHOISParams{Domain: "example.com", Display: "Registrar:(.*)"}
+
+	tile, err := usecase.WHOIS(params)
+	if assert.NoError(t, err) {
+		assert.Equal(t, "поле не найдено", tile.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- add `Display` field for WHOIS parameters
- support regex-based message parsing via `buildMessage`
- expose raw WHOIS data from repository
- update WHOIS usecases to use new display logic
- add unit tests for WHOIS display