### PR TITLE
Fix ping tile fractional ms display

### DIFF
--- a/ui/src/composables/useTileMetrics.ts
+++ b/ui/src/composables/useTileMetrics.ts
@@ -40,10 +40,15 @@ export default function useTileMetrics(state: ComputedRef<TileState | undefined>
       [TileValueUnit.Raw]: '',
     }
 
-    let value = values.value[values.value.length - 1]
-    if (unit.value === TileValueUnit.Millisecond) {
-      value = Math.round(parseFloat(value)).toString()
-    } else if (unit.value === TileValueUnit.Ratio) {
+      let value = values.value[values.value.length - 1]
+      if (unit.value === TileValueUnit.Millisecond) {
+        const floatValue = parseFloat(value)
+        if (floatValue >= 1) {
+          value = Math.round(floatValue).toString()
+        } else {
+          value = floatValue.toString()
+        }
+      } else if (unit.value === TileValueUnit.Ratio) {
       value = (parseFloat(value) * 100).toFixed(2).toString()
     }
 


### PR DESCRIPTION
## Summary
- preserve fractional millisecond values in the UI